### PR TITLE
Add macOS workflow for iOS API tests

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -37,4 +37,4 @@ jobs:
           xcodebuild test \
             -project Groceries.xcodeproj \
             -scheme GroceriesAPI \
-            -destination 'generic/platform=iOS Simulator'
+            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16'


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow at `.github/workflows/ios-tests.yml`
- run on macOS for iOS-compatible tooling
- generate the Xcode project with `tuist generate` and execute `GroceriesAPITests` via `xcodebuild test`

## Test Plan
- [x] workflow file reviewed for syntax and command flow
- [ ] validate first CI run on this PR