### PR TITLE
feat: add iOS items management tab and editor flow

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -35,32 +35,49 @@ jobs:
         working-directory: clients/ios
         run: |
           python3 - <<'PY'
-          import json
           import os
+          import re
           import subprocess
           import sys
 
-          data = json.loads(
-              subprocess.check_output(
-                  ["xcrun", "simctl", "list", "devices", "available", "-j"],
-                  text=True,
-              )
+          output = subprocess.check_output(
+              [
+                  "xcodebuild",
+                  "-showdestinations",
+                  "-project",
+                  "Groceries.xcodeproj",
+                  "-scheme",
+                  "GroceriesAPI",
+              ],
+              text=True,
           )
 
-          for runtime, devices in sorted(data.get("devices", {}).items()):
-              if "iOS" not in runtime:
-                  continue
-              for device in devices:
-                  if device.get("isAvailable") and "iPhone" in device.get("name", ""):
-                      with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
-                          env_file.write(f"IOS_SIMULATOR_ID={device['udid']}\n")
-                          env_file.write(
-                              f"IOS_SIMULATOR_NAME={device['name']} ({runtime})\n"
-                          )
-                      print(f"Using simulator: {device['name']} ({runtime})")
-                      sys.exit(0)
+          pattern = re.compile(
+              r"\{ platform:iOS Simulator, arch:[^,]+, id:([^,]+), OS:([^,]+), name:([^}]+) \}"
+          )
 
-          print("No available iPhone iOS simulator found", file=sys.stderr)
+          destinations = [
+              {
+                  "id": match.group(1).strip(),
+                  "os": match.group(2).strip(),
+                  "name": match.group(3).strip(),
+              }
+              for match in pattern.finditer(output)
+          ]
+
+          preferred = [d for d in destinations if "iPhone" in d["name"]]
+          selected = preferred[0] if preferred else (destinations[0] if destinations else None)
+
+          if selected is not None:
+              with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+                  env_file.write(f"IOS_SIMULATOR_ID={selected['id']}\n")
+                  env_file.write(
+                      f"IOS_SIMULATOR_NAME={selected['name']} (iOS {selected['os']})\n"
+                  )
+              print(f"Using simulator: {selected['name']} (iOS {selected['os']})")
+              sys.exit(0)
+
+          print("No eligible iOS simulator destination found", file=sys.stderr)
           sys.exit(1)
           PY
 

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -31,96 +31,18 @@ jobs:
         working-directory: clients/ios
         run: xcodebuild -list -project Groceries.xcodeproj
 
-      - name: Select available iOS simulator
-        working-directory: clients/ios
-        run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import re
-          import subprocess
-          import sys
-
-          result = subprocess.run(
-              ["xcodebuild", "-showdestinations", "-project", "Groceries.xcodeproj", "-scheme", "GroceriesAPI"],
-              text=True,
-              capture_output=True,
-              check=False,
-          )
-          output = f"{result.stdout}\n{result.stderr}"
-
-          pattern = re.compile(
-              r"\{ platform:iOS Simulator, arch:[^,]+, id:([^,]+), OS:([^,]+), name:([^}]+) \}"
-          )
-
-          destinations = [
-              {
-                  "id": match.group(1).strip(),
-                  "os": match.group(2).strip(),
-                  "name": match.group(3).strip(),
-              }
-              for match in pattern.finditer(output)
-          ]
-
-          preferred = [d for d in destinations if "iPhone" in d["name"]]
-          selected = preferred[0] if preferred else (destinations[0] if destinations else None)
-
-          if selected is None:
-              simctl = json.loads(
-                  subprocess.check_output(
-                      ["xcrun", "simctl", "list", "devices", "available", "-j"],
-                      text=True,
-                  )
-              )
-
-              fallback = []
-              for runtime, devices in sorted(simctl.get("devices", {}).items()):
-                  if "iOS" not in runtime:
-                      continue
-                  for device in devices:
-                      if device.get("isAvailable"):
-                          fallback.append(
-                              {
-                                  "id": device["udid"],
-                                  "name": device["name"],
-                                  "os": runtime,
-                              }
-                          )
-
-              preferred_fallback = [d for d in fallback if "iPhone" in d["name"]]
-              selected = preferred_fallback[0] if preferred_fallback else (fallback[0] if fallback else None)
-
-          if selected is not None:
-              with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
-                  env_file.write(f"IOS_SIMULATOR_ID={selected['id']}\n")
-                  env_file.write(
-                      f"IOS_SIMULATOR_NAME={selected['name']} (iOS {selected['os']})\n"
-                  )
-              print(f"Using simulator: {selected['name']} (iOS {selected['os']})")
-              sys.exit(0)
-
-          print("No eligible iOS simulator destination found", file=sys.stderr)
-          sys.exit(1)
-          PY
-
       - name: Run Groceries API unit tests
         working-directory: clients/ios
         run: |
-          echo "Testing on $IOS_SIMULATOR_NAME"
-          xcrun simctl boot "$IOS_SIMULATOR_ID" || true
-          xcrun simctl bootstatus "$IOS_SIMULATOR_ID" -b
           xcodebuild test \
             -project Groceries.xcodeproj \
             -scheme GroceriesAPI \
-            -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_ID"
+            -destination "platform=iOS Simulator,name=iPhone 16 Pro,OS=latest"
 
       - name: Run Groceries app feature unit tests
         working-directory: clients/ios
         run: |
-          echo "Testing on $IOS_SIMULATOR_NAME"
-          xcrun simctl boot "$IOS_SIMULATOR_ID" || true
-          xcrun simctl bootstatus "$IOS_SIMULATOR_ID" -b
           xcodebuild test \
             -project Groceries.xcodeproj \
             -scheme GroceriesTests \
-            -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_ID"
+            -destination "platform=iOS Simulator,name=iPhone 16 Pro,OS=latest"

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -31,18 +31,57 @@ jobs:
         working-directory: clients/ios
         run: xcodebuild -list -project Groceries.xcodeproj
 
+      - name: Select available iOS simulator
+        working-directory: clients/ios
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+
+          data = json.loads(
+              subprocess.check_output(
+                  ["xcrun", "simctl", "list", "devices", "available", "-j"],
+                  text=True,
+              )
+          )
+
+          for runtime, devices in sorted(data.get("devices", {}).items()):
+              if "iOS" not in runtime:
+                  continue
+              for device in devices:
+                  if device.get("isAvailable") and "iPhone" in device.get("name", ""):
+                      with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+                          env_file.write(f"IOS_SIMULATOR_ID={device['udid']}\n")
+                          env_file.write(
+                              f"IOS_SIMULATOR_NAME={device['name']} ({runtime})\n"
+                          )
+                      print(f"Using simulator: {device['name']} ({runtime})")
+                      sys.exit(0)
+
+          print("No available iPhone iOS simulator found", file=sys.stderr)
+          sys.exit(1)
+          PY
+
       - name: Run Groceries API unit tests
         working-directory: clients/ios
         run: |
+          echo "Testing on $IOS_SIMULATOR_NAME"
+          xcrun simctl boot "$IOS_SIMULATOR_ID" || true
+          xcrun simctl bootstatus "$IOS_SIMULATOR_ID" -b
           xcodebuild test \
             -project Groceries.xcodeproj \
             -scheme GroceriesAPI \
-            -destination 'platform=iOS Simulator,name=iPhone 17'
+            -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_ID"
 
       - name: Run Groceries app feature unit tests
         working-directory: clients/ios
         run: |
+          echo "Testing on $IOS_SIMULATOR_NAME"
+          xcrun simctl boot "$IOS_SIMULATOR_ID" || true
+          xcrun simctl bootstatus "$IOS_SIMULATOR_ID" -b
           xcodebuild test \
             -project Groceries.xcodeproj \
             -scheme GroceriesTests \
-            -destination 'platform=iOS Simulator,name=iPhone 17'
+            -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_ID"

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -35,22 +35,19 @@ jobs:
         working-directory: clients/ios
         run: |
           python3 - <<'PY'
+          import json
           import os
           import re
           import subprocess
           import sys
 
-          output = subprocess.check_output(
-              [
-                  "xcodebuild",
-                  "-showdestinations",
-                  "-project",
-                  "Groceries.xcodeproj",
-                  "-scheme",
-                  "GroceriesAPI",
-              ],
+          result = subprocess.run(
+              ["xcodebuild", "-showdestinations", "-project", "Groceries.xcodeproj", "-scheme", "GroceriesAPI"],
               text=True,
+              capture_output=True,
+              check=False,
           )
+          output = f"{result.stdout}\n{result.stderr}"
 
           pattern = re.compile(
               r"\{ platform:iOS Simulator, arch:[^,]+, id:([^,]+), OS:([^,]+), name:([^}]+) \}"
@@ -67,6 +64,31 @@ jobs:
 
           preferred = [d for d in destinations if "iPhone" in d["name"]]
           selected = preferred[0] if preferred else (destinations[0] if destinations else None)
+
+          if selected is None:
+              simctl = json.loads(
+                  subprocess.check_output(
+                      ["xcrun", "simctl", "list", "devices", "available", "-j"],
+                      text=True,
+                  )
+              )
+
+              fallback = []
+              for runtime, devices in sorted(simctl.get("devices", {}).items()):
+                  if "iOS" not in runtime:
+                      continue
+                  for device in devices:
+                      if device.get("isAvailable"):
+                          fallback.append(
+                              {
+                                  "id": device["udid"],
+                                  "name": device["name"],
+                                  "os": runtime,
+                              }
+                          )
+
+              preferred_fallback = [d for d in fallback if "iPhone" in d["name"]]
+              selected = preferred_fallback[0] if preferred_fallback else (fallback[0] if fallback else None)
 
           if selected is not None:
               with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -31,6 +31,13 @@ clients/ios/
 │   │       │   ├── AuthViewModel.swift
 │   │       │   ├── LoginView.swift
 │   │       │   └── KeychainStore.swift
+│   │       ├── Navigation/
+│   │       │   └── AppTabsView.swift
+│   │       ├── Items/
+│   │       │   ├── ItemsViewModel.swift
+│   │       │   ├── ItemsView.swift
+│   │       │   ├── AddItemView.swift
+│   │       │   └── ItemEditorView.swift
 │   │       └── ShoppingList/
 │   │           ├── ShoppingListViewModel.swift
 │   │           └── ShoppingListView.swift
@@ -38,9 +45,11 @@ clients/ios/
 │       ├── GroceriesAPIClient.swift
 │       ├── Models.swift
 │       ├── AuthEndpoints.swift
-│       └── ListEndpoints.swift
+│       ├── ListEndpoints.swift
+│       └── ItemEndpoints.swift
 └── Tests/
-    └── GroceriesAPITests/     # Unit tests for the API layer
+    ├── GroceriesAPITests/     # Unit tests for the API layer
+    └── GroceriesTests/        # Unit tests for app features/view models
 ```
 
 > **Xcode project files (`.xcodeproj`, `.xcworkspace`, `Derived/`) are git-ignored.**
@@ -133,8 +142,11 @@ GroceriesApp (@main)
 └── RootView               — routes between Login and main content
     ├── LoginView          — username/password form
     │   └── AuthViewModel  — owns GroceriesAPIClient, manages token lifecycle
-    └── ShoppingListView   — main list screen
-        └── ShoppingListViewModel — list state, optimistic updates
+    └── AppTabsView        — authenticated shell tab order: List -> Items -> Account
+        ├── ShoppingListView      — list screen with deduped auto-refresh coordinator
+        │   └── ShoppingListViewModel — list state and list mutations
+        └── ItemsView             — item management screen
+            └── ItemsViewModel    — item filtering, add/edit/delete, membership updates
 ```
 
 ### Key design decisions
@@ -144,7 +156,8 @@ GroceriesApp (@main)
 | `GroceriesAPI` is a separate framework target | Keeps networking/model code testable in isolation, independent of SwiftUI |
 | `GroceriesAPIClient` is an `actor` | Ensures token mutation is data-race safe across async contexts |
 | Bearer token stored in Keychain | Survives app restarts; more secure than `UserDefaults` |
-| Optimistic UI updates | Toggle/remove operations feel instant; rolled back on API error |
+| Dedicated `Features/Items` module | Keeps item CRUD and editor-only membership logic isolated from shopping list state |
+| Notification-based cross-tab sync | Item membership changes publish an app event consumed by shopping list refresh coordination |
 | No third-party dependencies (yet) | Reduces build complexity; revisit when pagination or richer offline support is needed |
 
 ## Running Tests
@@ -157,8 +170,8 @@ Or in Xcode: **⌘U**.
 
 ## Future Work
 
-- Category browsing and item search
-- Add items to the list from within the app
+- Offline caching/sync for list and item data
+- Bulk item operations (multi-select delete/category move)
 - Recipe support
 - macOS Catalyst / dedicated macOS target
 - Real-time updates via Server-Sent Events

--- a/clients/ios/Sources/Groceries/Features/Items/AddItemView.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/AddItemView.swift
@@ -1,6 +1,32 @@
 import SwiftUI
 import GroceriesAPI
 
+enum AddItemViewAccessibility {
+    static let categoryLabel = "Item category"
+    static let nameLabel = "Item name"
+    static let cancelButtonLabel = "Cancel add item"
+    static let saveButtonLabel = "Save item"
+    static let errorLabel = "Add item error"
+}
+
+enum AddItemViewUX {
+    static func cancelDisabled(isAdding: Bool) -> Bool {
+        isAdding
+    }
+
+    static func saveDisabled(isAdding: Bool, baseSaveDisabled: Bool) -> Bool {
+        isAdding || baseSaveDisabled
+    }
+
+    static func categoryDisabled(isAdding: Bool) -> Bool {
+        isAdding
+    }
+
+    static func nameDisabled(isAdding: Bool) -> Bool {
+        isAdding
+    }
+}
+
 struct AddItemView: View {
     @Environment(\.dismiss) private var dismiss
 
@@ -19,12 +45,21 @@ struct AddItemView: View {
                             Text(category.name).tag(Optional(category.id))
                         }
                     }
-                    .disabled(viewModel.isAddCategoryPickerDisabled)
-                    .accessibilityLabel("Item category")
+                    .disabled(AddItemViewUX.categoryDisabled(isAdding: viewModel.isAdding))
+                    .accessibilityLabel(AddItemViewAccessibility.categoryLabel)
 
                     TextField("Item name", text: $name)
-                        .disabled(viewModel.isAddNameFieldDisabled)
-                        .accessibilityLabel("Item name")
+                        .disabled(AddItemViewUX.nameDisabled(isAdding: viewModel.isAdding))
+                        .accessibilityLabel(AddItemViewAccessibility.nameLabel)
+                }
+
+                if let errorMessage = viewModel.errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                            .accessibilityLabel(AddItemViewAccessibility.errorLabel)
+                            .accessibilityValue(errorMessage)
+                    }
                 }
             }
             .navigationTitle("Add Item")
@@ -34,8 +69,8 @@ struct AddItemView: View {
                     Button("Cancel") {
                         dismiss()
                     }
-                    .disabled(viewModel.isAdding)
-                    .accessibilityLabel("Cancel add item")
+                    .disabled(AddItemViewUX.cancelDisabled(isAdding: viewModel.isAdding))
+                    .accessibilityLabel(AddItemViewAccessibility.cancelButtonLabel)
                 }
 
                 ToolbarItem(placement: .confirmationAction) {
@@ -47,8 +82,16 @@ struct AddItemView: View {
                             }
                         }
                     }
-                    .disabled(viewModel.isAddButtonDisabled(name: name, categoryID: selectedCategoryID))
-                    .accessibilityLabel("Save item")
+                    .disabled(
+                        AddItemViewUX.saveDisabled(
+                            isAdding: viewModel.isAdding,
+                            baseSaveDisabled: viewModel.isAddButtonDisabled(
+                                name: name,
+                                categoryID: selectedCategoryID
+                            )
+                        )
+                    )
+                    .accessibilityLabel(AddItemViewAccessibility.saveButtonLabel)
                 }
             }
         }

--- a/clients/ios/Sources/Groceries/Features/Items/AddItemView.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/AddItemView.swift
@@ -53,7 +53,7 @@ struct AddItemView: View {
                         .accessibilityLabel(AddItemViewAccessibility.nameLabel)
                 }
 
-                if let errorMessage = viewModel.errorMessage {
+                if let errorMessage = viewModel.mutationErrorMessage {
                     Section {
                         Text(errorMessage)
                             .foregroundStyle(.red)

--- a/clients/ios/Sources/Groceries/Features/Items/AddItemView.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/AddItemView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import GroceriesAPI
+
+struct AddItemView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let viewModel: ItemsViewModel
+
+    @State private var selectedCategoryID: Int?
+    @State private var name = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Details") {
+                    Picker("Category", selection: $selectedCategoryID) {
+                        Text("Select category").tag(Optional<Int>.none)
+                        ForEach(viewModel.categories) { category in
+                            Text(category.name).tag(Optional(category.id))
+                        }
+                    }
+                    .disabled(viewModel.isAddCategoryPickerDisabled)
+                    .accessibilityLabel("Item category")
+
+                    TextField("Item name", text: $name)
+                        .disabled(viewModel.isAddNameFieldDisabled)
+                        .accessibilityLabel("Item name")
+                }
+            }
+            .navigationTitle("Add Item")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .disabled(viewModel.isAdding)
+                    .accessibilityLabel("Cancel add item")
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task {
+                            let success = await viewModel.addItem(name: name, categoryID: selectedCategoryID)
+                            if success {
+                                dismiss()
+                            }
+                        }
+                    }
+                    .disabled(viewModel.isAddButtonDisabled(name: name, categoryID: selectedCategoryID))
+                    .accessibilityLabel("Save item")
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    let apiClient = GroceriesAPIClient(baseURL: URL(string: "http://localhost:3000")!)
+    let viewModel = ItemsViewModel(api: apiClient)
+    AddItemView(viewModel: viewModel)
+}

--- a/clients/ios/Sources/Groceries/Features/Items/ItemEditorView.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemEditorView.swift
@@ -1,0 +1,238 @@
+import SwiftUI
+import GroceriesAPI
+
+enum ItemEditorViewAccessibility {
+    static let categoryLabel = "Edit item category"
+    static let nameLabel = "Edit item name"
+    static let membershipToggleLabel = "Include item in shopping list"
+    static let cancelButtonLabel = "Cancel edit item"
+    static let saveButtonLabel = "Save item changes"
+    static let deleteButtonLabel = "Delete item"
+    static let deleteConfirmButtonLabel = "Confirm delete item"
+    static let errorLabel = "Edit item error"
+}
+
+enum ItemEditorViewUX {
+    static func cancelDisabled(isMutationInFlight: Bool) -> Bool {
+        isMutationInFlight
+    }
+
+    static func saveDisabled(isMutationInFlight: Bool, baseSaveDisabled: Bool) -> Bool {
+        isMutationInFlight || baseSaveDisabled
+    }
+
+    static func nameDisabled(isMutationInFlight: Bool) -> Bool {
+        isMutationInFlight
+    }
+
+    static func categoryDisabled(isMutationInFlight: Bool) -> Bool {
+        isMutationInFlight
+    }
+
+    static func membershipToggleDisabled(isMutationInFlight: Bool) -> Bool {
+        isMutationInFlight
+    }
+
+    static func deleteDisabled(isMutationInFlight: Bool) -> Bool {
+        isMutationInFlight
+    }
+
+    struct MembershipToggleMutation {
+        let visibleValue: Bool
+        let requestedValue: Bool
+    }
+
+    static func membershipToggleInitialState(isInList: Bool) -> MembershipToggleMutation {
+        MembershipToggleMutation(visibleValue: isInList, requestedValue: isInList)
+    }
+
+    static func membershipToggleBeginMutation(currentVisibleValue: Bool, requestedValue: Bool) -> MembershipToggleMutation {
+        MembershipToggleMutation(visibleValue: currentVisibleValue, requestedValue: requestedValue)
+    }
+
+    static func membershipToggleResolveMutation(
+        currentVisibleValue: Bool,
+        requestedValue: Bool,
+        success: Bool
+    ) -> Bool {
+        if success {
+            return requestedValue
+        }
+        return currentVisibleValue
+    }
+
+    static func membershipToggleSyncExternalModelChange(
+        currentVisibleValue: Bool,
+        modelIsInList: Bool,
+        isMutationInFlight: Bool
+    ) -> Bool {
+        guard !isMutationInFlight else {
+            return currentVisibleValue
+        }
+        return modelIsInList
+    }
+}
+
+struct ItemEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let item: Item
+    let viewModel: ItemsViewModel
+
+    @State private var selectedCategoryID: Int?
+    @State private var name: String
+    @State private var isInList: Bool
+    @State private var isShowingDeleteConfirmation = false
+
+    init(item: Item, viewModel: ItemsViewModel) {
+        self.item = item
+        self.viewModel = viewModel
+        _selectedCategoryID = State(initialValue: item.categoryID)
+        _name = State(initialValue: item.name)
+        _isInList = State(initialValue: ItemEditorViewUX.membershipToggleInitialState(isInList: item.list != nil).visibleValue)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Details") {
+                    Picker("Category", selection: $selectedCategoryID) {
+                        Text("Select category").tag(Optional<Int>.none)
+                        ForEach(viewModel.categories) { category in
+                            Text(category.name).tag(Optional(category.id))
+                        }
+                    }
+                    .disabled(ItemEditorViewUX.categoryDisabled(isMutationInFlight: isMutationInFlight))
+                    .accessibilityLabel(ItemEditorViewAccessibility.categoryLabel)
+
+                    TextField("Item name", text: $name)
+                        .disabled(ItemEditorViewUX.nameDisabled(isMutationInFlight: isMutationInFlight))
+                        .accessibilityLabel(ItemEditorViewAccessibility.nameLabel)
+                }
+
+                Section("Shopping List") {
+                    Toggle(
+                        "In shopping list",
+                        isOn: Binding(
+                            get: { isInList },
+                            set: { nextValue in
+                                let mutation = ItemEditorViewUX.membershipToggleBeginMutation(
+                                    currentVisibleValue: isInList,
+                                    requestedValue: nextValue
+                                )
+                                guard mutation.requestedValue != mutation.visibleValue else {
+                                    return
+                                }
+                                guard !isMutationInFlight else {
+                                    return
+                                }
+
+                                Task {
+                                    let success = await viewModel.setInList(
+                                        itemID: item.id,
+                                        isInList: mutation.requestedValue
+                                    )
+                                    isInList = ItemEditorViewUX.membershipToggleResolveMutation(
+                                        currentVisibleValue: mutation.visibleValue,
+                                        requestedValue: mutation.requestedValue,
+                                        success: success
+                                    )
+                                }
+                            }
+                        )
+                    )
+                        .disabled(ItemEditorViewUX.membershipToggleDisabled(isMutationInFlight: isMutationInFlight))
+                        .accessibilityLabel(ItemEditorViewAccessibility.membershipToggleLabel)
+                }
+
+                Section {
+                    Button("Delete Item", role: .destructive) {
+                        isShowingDeleteConfirmation = true
+                    }
+                    .disabled(ItemEditorViewUX.deleteDisabled(isMutationInFlight: isMutationInFlight))
+                    .accessibilityLabel(ItemEditorViewAccessibility.deleteButtonLabel)
+                }
+
+                if let errorMessage = viewModel.errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                            .accessibilityLabel(ItemEditorViewAccessibility.errorLabel)
+                            .accessibilityValue(errorMessage)
+                    }
+                }
+            }
+            .navigationTitle("Edit Item")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .disabled(ItemEditorViewUX.cancelDisabled(isMutationInFlight: isMutationInFlight))
+                    .accessibilityLabel(ItemEditorViewAccessibility.cancelButtonLabel)
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task {
+                            let success = await viewModel.updateItem(
+                                id: item.id,
+                                name: name,
+                                categoryID: selectedCategoryID
+                            )
+                            if success {
+                                dismiss()
+                            }
+                        }
+                    }
+                    .disabled(
+                        ItemEditorViewUX.saveDisabled(
+                            isMutationInFlight: isMutationInFlight,
+                            baseSaveDisabled: isSaveInputInvalid
+                        )
+                    )
+                    .accessibilityLabel(ItemEditorViewAccessibility.saveButtonLabel)
+                }
+            }
+        }
+        .interactiveDismissDisabled(isMutationInFlight)
+        .onChange(of: modelIsInList) { _, nextModelIsInList in
+            isInList = ItemEditorViewUX.membershipToggleSyncExternalModelChange(
+                currentVisibleValue: isInList,
+                modelIsInList: nextModelIsInList,
+                isMutationInFlight: isMutationInFlight
+            )
+        }
+        .confirmationDialog("Delete this item?", isPresented: $isShowingDeleteConfirmation) {
+            Button("Delete", role: .destructive) {
+                Task {
+                    let success = await viewModel.deleteItem(id: item.id)
+                    if success {
+                        dismiss()
+                    }
+                }
+            }
+            .accessibilityLabel(ItemEditorViewAccessibility.deleteConfirmButtonLabel)
+
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This action cannot be undone.")
+        }
+    }
+
+    private var isMutationInFlight: Bool {
+        viewModel.mutatingItemIDs.contains(item.id)
+    }
+
+    private var isSaveInputInvalid: Bool {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || selectedCategoryID == nil
+    }
+
+    private var modelIsInList: Bool {
+        if let updated = viewModel.items.first(where: { $0.id == item.id }) {
+            return updated.list != nil
+        }
+        return item.list != nil
+    }
+}

--- a/clients/ios/Sources/Groceries/Features/Items/ItemEditorView.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemEditorView.swift
@@ -153,7 +153,7 @@ struct ItemEditorView: View {
                     .accessibilityLabel(ItemEditorViewAccessibility.deleteButtonLabel)
                 }
 
-                if let errorMessage = viewModel.errorMessage {
+                if let errorMessage = viewModel.mutationErrorMessage {
                     Section {
                         Text(errorMessage)
                             .foregroundStyle(.red)

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
@@ -39,8 +39,13 @@ enum ItemsViewUX {
         isAdding
     }
 
-    static func shouldShowRetryAffordance(isLoading: Bool, filteredItems: [Item], errorMessage: String?) -> Bool {
-        !isLoading && filteredItems.isEmpty && errorMessage != nil
+    static func shouldShowRetryAffordance(
+        isLoading: Bool,
+        filteredItems: [Item],
+        loadErrorMessage: String?,
+        mutationErrorMessage _: String?
+    ) -> Bool {
+        !isLoading && filteredItems.isEmpty && loadErrorMessage != nil
     }
 
     static func performRetry(using action: () async -> Void) async {
@@ -91,7 +96,8 @@ struct ItemsView: View {
                             if ItemsViewUX.shouldShowRetryAffordance(
                                 isLoading: viewModel.isLoading,
                                 filteredItems: viewModel.filteredItems,
-                                errorMessage: viewModel.errorMessage
+                                loadErrorMessage: viewModel.loadErrorMessage,
+                                mutationErrorMessage: viewModel.mutationErrorMessage
                             ) {
                                 ContentUnavailableView {
                                     Label("Unable to load items", systemImage: "exclamationmark.triangle")

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
@@ -1,6 +1,22 @@
 import SwiftUI
 import GroceriesAPI
 
+enum ItemsViewRoute: Hashable {
+    case editor(itemID: Int)
+}
+
+enum ItemMembershipToggleContext {
+    case listRows
+    case addItemForm
+    case editor
+}
+
+enum ItemMembershipToggleAccess {
+    static func isAvailable(in context: ItemMembershipToggleContext) -> Bool {
+        context == .editor
+    }
+}
+
 enum ItemsViewAccessibility {
     static let searchFieldLabel = "Item search"
     static let inListOnlyToggleLabel = "In List only"
@@ -8,8 +24,27 @@ enum ItemsViewAccessibility {
 }
 
 enum ItemsViewUX {
+    static func editorRoute(for item: Item) -> ItemsViewRoute {
+        .editor(itemID: item.id)
+    }
+
+    static func editorItem(for route: ItemsViewRoute, items: [Item]) -> Item? {
+        switch route {
+        case .editor(let itemID):
+            return items.first(where: { $0.id == itemID })
+        }
+    }
+
     static func addSheetInteractiveDismissDisabled(isAdding: Bool) -> Bool {
         isAdding
+    }
+
+    static func shouldShowRetryAffordance(isLoading: Bool, filteredItems: [Item], errorMessage: String?) -> Bool {
+        !isLoading && filteredItems.isEmpty && errorMessage != nil
+    }
+
+    static func performRetry(using action: () async -> Void) async {
+        await action()
     }
 }
 
@@ -18,6 +53,7 @@ struct ItemsView: View {
 
     @State private var viewModel: ItemsViewModel
     @State private var isPresentingAddItem = false
+    @State private var navigationPath: [ItemsViewRoute] = []
 
     init(apiClient: GroceriesAPIClient) {
         self.apiClient = apiClient
@@ -25,7 +61,7 @@ struct ItemsView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $navigationPath) {
             ZStack {
                 AppBackground()
 
@@ -52,24 +88,44 @@ struct ItemsView: View {
 
                     if viewModel.filteredItems.isEmpty && !viewModel.isLoading {
                         Section {
-                            ContentUnavailableView(
-                                "No items",
-                                systemImage: "square.grid.2x2",
-                                description: Text("Try adjusting search or add a new item.")
-                            )
+                            if ItemsViewUX.shouldShowRetryAffordance(
+                                isLoading: viewModel.isLoading,
+                                filteredItems: viewModel.filteredItems,
+                                errorMessage: viewModel.errorMessage
+                            ) {
+                                ContentUnavailableView {
+                                    Label("Unable to load items", systemImage: "exclamationmark.triangle")
+                                } description: {
+                                    Text("Please try again.")
+                                } actions: {
+                                    Button("Retry") {
+                                        Task {
+                                            await ItemsViewUX.performRetry(using: viewModel.retryLoad)
+                                        }
+                                    }
+                                }
+                            } else {
+                                ContentUnavailableView(
+                                    "No items",
+                                    systemImage: "square.grid.2x2",
+                                    description: Text("Try adjusting search or add a new item.")
+                                )
+                            }
                         }
                     } else {
                         Section {
                             ForEach(viewModel.filteredItems) { item in
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text(item.name)
-                                        .foregroundStyle(.white)
-                                    Text(item.categoryName)
-                                        .font(.caption)
-                                        .foregroundStyle(.white.opacity(0.75))
+                                NavigationLink(value: ItemsViewUX.editorRoute(for: item)) {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(item.name)
+                                            .foregroundStyle(.white)
+                                        Text(item.categoryName)
+                                            .font(.caption)
+                                            .foregroundStyle(.white.opacity(0.75))
+                                    }
+                                    .accessibilityElement(children: .combine)
+                                    .accessibilityLabel(item.list == nil ? "\(item.name), \(item.categoryName)" : "\(item.name), \(item.categoryName), in list")
                                 }
-                                .accessibilityElement(children: .combine)
-                                .accessibilityLabel(item.list == nil ? "\(item.name), \(item.categoryName)" : "\(item.name), \(item.categoryName), in list")
                             }
                         }
                     }
@@ -77,6 +133,9 @@ struct ItemsView: View {
                 .listStyle(.insetGrouped)
                 .scrollContentBackground(.hidden)
                 .environment(\.colorScheme, .dark)
+                .refreshable {
+                    await viewModel.refresh()
+                }
             }
             .navigationTitle("Items")
             .navigationBarTitleDisplayMode(.inline)
@@ -94,6 +153,17 @@ struct ItemsView: View {
                 }
             }
             .task { await viewModel.load() }
+            .navigationDestination(for: ItemsViewRoute.self) { route in
+                if let item = ItemsViewUX.editorItem(for: route, items: viewModel.items) {
+                    ItemEditorView(item: item, viewModel: viewModel)
+                } else {
+                    ContentUnavailableView(
+                        "Item unavailable",
+                        systemImage: "questionmark.square",
+                        description: Text("This item could not be found.")
+                    )
+                }
+            }
             .sheet(isPresented: $isPresentingAddItem) {
                 AddItemView(viewModel: viewModel)
                     .interactiveDismissDisabled(ItemsViewUX.addSheetInteractiveDismissDisabled(isAdding: viewModel.isAdding))

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
@@ -1,6 +1,18 @@
 import SwiftUI
 import GroceriesAPI
 
+enum ItemsViewAccessibility {
+    static let searchFieldLabel = "Item search"
+    static let inListOnlyToggleLabel = "In List only"
+    static let addItemButtonLabel = "Add item"
+}
+
+enum ItemsViewUX {
+    static func addSheetInteractiveDismissDisabled(isAdding: Bool) -> Bool {
+        isAdding
+    }
+}
+
 struct ItemsView: View {
     let apiClient: GroceriesAPIClient
 
@@ -26,7 +38,7 @@ struct ItemsView: View {
                                 set: { viewModel.searchText = $0 }
                             )
                         )
-                        .accessibilityLabel("Item search")
+                        .accessibilityLabel(ItemsViewAccessibility.searchFieldLabel)
 
                         Toggle(
                             "In List only",
@@ -35,7 +47,7 @@ struct ItemsView: View {
                                 set: { viewModel.inListOnly = $0 }
                             )
                         )
-                        .accessibilityLabel("In List only")
+                        .accessibilityLabel(ItemsViewAccessibility.inListOnlyToggleLabel)
                     }
 
                     if viewModel.filteredItems.isEmpty && !viewModel.isLoading {
@@ -78,12 +90,13 @@ struct ItemsView: View {
                     } label: {
                         Label("Add Item", systemImage: "plus")
                     }
-                    .accessibilityLabel("Add item")
+                    .accessibilityLabel(ItemsViewAccessibility.addItemButtonLabel)
                 }
             }
             .task { await viewModel.load() }
             .sheet(isPresented: $isPresentingAddItem) {
                 AddItemView(viewModel: viewModel)
+                    .interactiveDismissDisabled(ItemsViewUX.addSheetInteractiveDismissDisabled(isAdding: viewModel.isAdding))
             }
         }
     }

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
@@ -4,9 +4,87 @@ import GroceriesAPI
 struct ItemsView: View {
     let apiClient: GroceriesAPIClient
 
+    @State private var viewModel: ItemsViewModel
+    @State private var isPresentingAddItem = false
+
+    init(apiClient: GroceriesAPIClient) {
+        self.apiClient = apiClient
+        _viewModel = State(initialValue: ItemsViewModel(api: apiClient))
+    }
+
     var body: some View {
         NavigationStack {
-            Text("Items")
+            ZStack {
+                AppBackground()
+
+                List {
+                    Section {
+                        TextField(
+                            "Search items",
+                            text: Binding(
+                                get: { viewModel.searchText },
+                                set: { viewModel.searchText = $0 }
+                            )
+                        )
+                        .accessibilityLabel("Item search")
+
+                        Toggle(
+                            "In List only",
+                            isOn: Binding(
+                                get: { viewModel.inListOnly },
+                                set: { viewModel.inListOnly = $0 }
+                            )
+                        )
+                        .accessibilityLabel("In List only")
+                    }
+
+                    if viewModel.filteredItems.isEmpty && !viewModel.isLoading {
+                        Section {
+                            ContentUnavailableView(
+                                "No items",
+                                systemImage: "square.grid.2x2",
+                                description: Text("Try adjusting search or add a new item.")
+                            )
+                        }
+                    } else {
+                        Section {
+                            ForEach(viewModel.filteredItems) { item in
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(item.name)
+                                        .foregroundStyle(.white)
+                                    Text(item.categoryName)
+                                        .font(.caption)
+                                        .foregroundStyle(.white.opacity(0.75))
+                                }
+                                .accessibilityElement(children: .combine)
+                                .accessibilityLabel(item.list == nil ? "\(item.name), \(item.categoryName)" : "\(item.name), \(item.categoryName), in list")
+                            }
+                        }
+                    }
+                }
+                .listStyle(.insetGrouped)
+                .scrollContentBackground(.hidden)
+                .environment(\.colorScheme, .dark)
+            }
+            .navigationTitle("Items")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbarBackground(.clear, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        isPresentingAddItem = true
+                    } label: {
+                        Label("Add Item", systemImage: "plus")
+                    }
+                    .accessibilityLabel("Add item")
+                }
+            }
+            .task { await viewModel.load() }
+            .sheet(isPresented: $isPresentingAddItem) {
+                AddItemView(viewModel: viewModel)
+            }
         }
     }
 }

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import GroceriesAPI
+
+struct ItemsView: View {
+    let apiClient: GroceriesAPIClient
+
+    var body: some View {
+        NavigationStack {
+            Text("Items")
+        }
+    }
+}

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
@@ -24,6 +24,10 @@ enum ItemsViewAccessibility {
 }
 
 enum ItemsViewUX {
+    static func shouldUsePathDrivenNavigation() -> Bool {
+        false
+    }
+
     static func editorRoute(for item: Item) -> ItemsViewRoute {
         .editor(itemID: item.id)
     }
@@ -58,15 +62,13 @@ struct ItemsView: View {
 
     @State private var viewModel: ItemsViewModel
     @State private var isPresentingAddItem = false
-    @State private var navigationPath: [ItemsViewRoute] = []
-
     init(apiClient: GroceriesAPIClient) {
         self.apiClient = apiClient
         _viewModel = State(initialValue: ItemsViewModel(api: apiClient))
     }
 
     var body: some View {
-        NavigationStack(path: $navigationPath) {
+        NavigationStack {
             ZStack {
                 AppBackground()
 
@@ -121,7 +123,9 @@ struct ItemsView: View {
                     } else {
                         Section {
                             ForEach(viewModel.filteredItems) { item in
-                                NavigationLink(value: ItemsViewUX.editorRoute(for: item)) {
+                                NavigationLink {
+                                    ItemEditorView(item: item, viewModel: viewModel)
+                                } label: {
                                     VStack(alignment: .leading, spacing: 4) {
                                         Text(item.name)
                                             .foregroundStyle(.white)
@@ -159,17 +163,6 @@ struct ItemsView: View {
                 }
             }
             .task { await viewModel.load() }
-            .navigationDestination(for: ItemsViewRoute.self) { route in
-                if let item = ItemsViewUX.editorItem(for: route, items: viewModel.items) {
-                    ItemEditorView(item: item, viewModel: viewModel)
-                } else {
-                    ContentUnavailableView(
-                        "Item unavailable",
-                        systemImage: "questionmark.square",
-                        description: Text("This item could not be found.")
-                    )
-                }
-            }
             .sheet(isPresented: $isPresentingAddItem) {
                 AddItemView(viewModel: viewModel)
                     .interactiveDismissDisabled(ItemsViewUX.addSheetInteractiveDismissDisabled(isAdding: viewModel.isAdding))

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
@@ -1,0 +1,221 @@
+import Foundation
+import GroceriesAPI
+
+protocol ItemsAPI: Sendable {
+    func listCategories() async throws -> [GroceriesAPI.Category]
+    func listItems(inList: Bool?) async throws -> [Item]
+    func createItem(categoryID: Int, name: String) async throws -> Item
+    func updateItem(id: Int, categoryID: Int, name: String) async throws -> Item
+    func deleteItem(id: Int) async throws
+    func addItemToList(itemID: Int) async throws -> Item
+    func removeItemFromList(itemID: Int) async throws
+}
+
+extension GroceriesAPIClient: ItemsAPI {
+    func listItems(inList: Bool?) async throws -> [Item] {
+        try await listItems(categoryID: nil, inList: inList)
+    }
+
+    func addItemToList(itemID: Int) async throws -> Item {
+        _ = try await addItemToList(itemID: itemID, quantity: "")
+        let items = try await listItems(inList: true)
+        guard let item = items.first(where: { $0.id == itemID }) else {
+            throw APIError.notFound("Item not found")
+        }
+        return item
+    }
+}
+
+@Observable
+@MainActor
+final class ItemsViewModel {
+    private(set) var items: [Item] = []
+    private(set) var filteredItems: [Item] = []
+    private(set) var categories: [GroceriesAPI.Category] = []
+    private(set) var errorMessage: String?
+
+    private(set) var isLoading = false
+    private(set) var isAdding = false
+    private(set) var isUpdating = false
+    private(set) var mutatingItemIDs: Set<Int> = []
+
+    var searchText: String = "" {
+        didSet { applyFilters() }
+    }
+
+    var inListOnly: Bool = false {
+        didSet { applyFilters() }
+    }
+
+    private let api: any ItemsAPI
+    private let notificationCenter: NotificationCenter
+
+    init(api: any ItemsAPI, notificationCenter: NotificationCenter = .default) {
+        self.api = api
+        self.notificationCenter = notificationCenter
+    }
+
+    func load() async {
+        await load(force: false)
+    }
+
+    func retryLoad() async {
+        await load(force: true)
+    }
+
+    func refresh() async {
+        await load(force: true)
+    }
+
+    func addItem(name: String, categoryID: Int?) async -> Bool {
+        guard let validated = validatedInput(name: name, categoryID: categoryID) else {
+            return false
+        }
+        guard !isAdding else { return false }
+
+        isAdding = true
+        defer { isAdding = false }
+
+        do {
+            let item = try await api.createItem(categoryID: validated.categoryID, name: validated.name)
+            items.append(item)
+            errorMessage = nil
+            applyFilters()
+            return true
+        } catch {
+            errorMessage = errorDescription(error)
+            return false
+        }
+    }
+
+    func updateItem(id: Int, name: String, categoryID: Int?) async -> Bool {
+        guard let validated = validatedInput(name: name, categoryID: categoryID) else {
+            return false
+        }
+        guard !isUpdating else { return false }
+
+        isUpdating = true
+        defer { isUpdating = false }
+
+        do {
+            let updated = try await api.updateItem(id: id, categoryID: validated.categoryID, name: validated.name)
+            if let index = items.firstIndex(where: { $0.id == id }) {
+                items[index] = updated
+            }
+            errorMessage = nil
+            applyFilters()
+            return true
+        } catch {
+            errorMessage = errorDescription(error)
+            return false
+        }
+    }
+
+    func deleteItem(id: Int) async -> Bool {
+        guard !mutatingItemIDs.contains(id) else { return false }
+        mutatingItemIDs.insert(id)
+        defer { mutatingItemIDs.remove(id) }
+
+        do {
+            try await api.deleteItem(id: id)
+            items.removeAll(where: { $0.id == id })
+            errorMessage = nil
+            applyFilters()
+            return true
+        } catch {
+            errorMessage = errorDescription(error)
+            return false
+        }
+    }
+
+    func setInList(itemID: Int, isInList: Bool) async -> Bool {
+        guard !mutatingItemIDs.contains(itemID) else { return false }
+        guard items.contains(where: { $0.id == itemID }) else { return false }
+
+        mutatingItemIDs.insert(itemID)
+        defer { mutatingItemIDs.remove(itemID) }
+
+        do {
+            if isInList {
+                _ = try await api.addItemToList(itemID: itemID)
+            } else {
+                try await api.removeItemFromList(itemID: itemID)
+            }
+
+            items = try await api.listItems(inList: nil)
+            errorMessage = nil
+            applyFilters()
+
+            notificationCenter.post(
+                name: AppEvents.MembershipChanged.name,
+                object: nil,
+                userInfo: [
+                    AppEvents.MembershipChanged.itemIDKey: itemID,
+                    AppEvents.MembershipChanged.isInListKey: isInList,
+                    AppEvents.MembershipChanged.changedAtKey: Date(),
+                ]
+            )
+            return true
+        } catch {
+            errorMessage = errorDescription(error)
+            return false
+        }
+    }
+
+    private func load(force: Bool) async {
+        guard force || !isLoading else { return }
+
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            async let categoriesFetch = api.listCategories()
+            async let itemsFetch = api.listItems(inList: nil)
+            let (fetchedCategories, fetchedItems) = try await (categoriesFetch, itemsFetch)
+
+            categories = fetchedCategories
+            items = fetchedItems
+            errorMessage = nil
+            applyFilters()
+        } catch {
+            errorMessage = errorDescription(error)
+        }
+    }
+
+    private func applyFilters() {
+        var next = items
+
+        if inListOnly {
+            next = next.filter { $0.list != nil }
+        }
+
+        let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedSearch.isEmpty {
+            next = next.filter {
+                $0.name.range(of: trimmedSearch, options: .caseInsensitive) != nil
+            }
+        }
+
+        filteredItems = next
+    }
+
+    private func validatedInput(name: String, categoryID: Int?) -> (name: String, categoryID: Int)? {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            errorMessage = "Item name is required."
+            return nil
+        }
+        guard let categoryID else {
+            errorMessage = "Category is required."
+            return nil
+        }
+        return (name: trimmedName, categoryID: categoryID)
+    }
+
+    private func errorDescription(_ error: Error) -> String {
+        if let apiError = error as? APIError {
+            return apiError.errorDescription ?? error.localizedDescription
+        }
+        return error.localizedDescription
+    }
+}

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
@@ -7,7 +7,7 @@ protocol ItemsAPI: Sendable {
     func createItem(categoryID: Int, name: String) async throws -> Item
     func updateItem(id: Int, categoryID: Int, name: String) async throws -> Item
     func deleteItem(id: Int) async throws
-    func addItemToList(itemID: Int) async throws -> Item
+    func addItemToList(itemID: Int) async throws
     func removeItemFromList(itemID: Int) async throws
 }
 
@@ -16,13 +16,8 @@ extension GroceriesAPIClient: ItemsAPI {
         try await listItems(categoryID: nil, inList: inList)
     }
 
-    func addItemToList(itemID: Int) async throws -> Item {
+    func addItemToList(itemID: Int) async throws {
         _ = try await addItemToList(itemID: itemID, quantity: "")
-        let items = try await listItems(inList: true)
-        guard let item = items.first(where: { $0.id == itemID }) else {
-            throw APIError.notFound("Item not found")
-        }
-        return item
     }
 }
 

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
@@ -49,6 +49,8 @@ final class ItemsViewModel {
 
     private let api: any ItemsAPI
     private let notificationCenter: NotificationCenter
+    private var activeLoadCount = 0
+    private var latestLoadID = 0
 
     init(api: any ItemsAPI, notificationCenter: NotificationCenter = .default) {
         self.api = api
@@ -165,19 +167,29 @@ final class ItemsViewModel {
     private func load(force: Bool) async {
         guard force || !isLoading else { return }
 
+        latestLoadID += 1
+        let loadID = latestLoadID
+
+        activeLoadCount += 1
         isLoading = true
-        defer { isLoading = false }
+        defer {
+            activeLoadCount = max(0, activeLoadCount - 1)
+            isLoading = activeLoadCount > 0
+        }
 
         do {
             async let categoriesFetch = api.listCategories()
             async let itemsFetch = api.listItems(inList: nil)
             let (fetchedCategories, fetchedItems) = try await (categoriesFetch, itemsFetch)
 
+            guard loadID == latestLoadID else { return }
+
             categories = fetchedCategories
             items = fetchedItems
             errorMessage = nil
             applyFilters()
         } catch {
+            guard loadID == latestLoadID else { return }
             errorMessage = errorDescription(error)
         }
     }

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
@@ -39,6 +39,9 @@ final class ItemsViewModel {
     private(set) var isUpdating = false
     private(set) var mutatingItemIDs: Set<Int> = []
 
+    var isAddCategoryPickerDisabled: Bool { isAdding }
+    var isAddNameFieldDisabled: Bool { isAdding }
+
     var searchText: String = "" {
         didSet { applyFilters() }
     }
@@ -88,6 +91,12 @@ final class ItemsViewModel {
             errorMessage = errorDescription(error)
             return false
         }
+    }
+
+    func isAddButtonDisabled(name: String, categoryID: Int?) -> Bool {
+        guard !isAdding else { return true }
+        guard categoryID != nil else { return true }
+        return name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     func updateItem(id: Int, name: String, categoryID: Int?) async -> Bool {

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
@@ -147,7 +147,7 @@ final class ItemsViewModel {
 
     func setInList(itemID: Int, isInList: Bool) async -> Bool {
         guard !mutatingItemIDs.contains(itemID) else { return false }
-        guard items.contains(where: { $0.id == itemID }) else { return false }
+        guard let targetIndex = items.firstIndex(where: { $0.id == itemID }) else { return false }
 
         mutatingItemIDs.insert(itemID)
         defer { mutatingItemIDs.remove(itemID) }
@@ -159,9 +159,17 @@ final class ItemsViewModel {
                 try await api.removeItemFromList(itemID: itemID)
             }
 
-            items = try await api.listItems(inList: nil)
-            mutationErrorMessage = nil
-            applyFilters()
+            let existing = items[targetIndex]
+            let updatedMembership = isInList
+                ? ListItemSummary(id: existing.list?.id ?? itemID, quantity: existing.list?.quantity ?? "", done: existing.list?.done ?? false)
+                : nil
+            items[targetIndex] = Item(
+                id: existing.id,
+                categoryID: existing.categoryID,
+                categoryName: existing.categoryName,
+                name: existing.name,
+                list: updatedMembership
+            )
 
             notificationCenter.post(
                 name: AppEvents.MembershipChanged.name,
@@ -172,6 +180,12 @@ final class ItemsViewModel {
                     AppEvents.MembershipChanged.changedAtKey: Date(),
                 ]
             )
+
+            if let refreshed = try? await api.listItems(inList: nil) {
+                items = refreshed
+            }
+            mutationErrorMessage = nil
+            applyFilters()
             return true
         } catch {
             mutationErrorMessage = errorDescription(error)

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
@@ -32,7 +32,8 @@ final class ItemsViewModel {
     private(set) var items: [Item] = []
     private(set) var filteredItems: [Item] = []
     private(set) var categories: [GroceriesAPI.Category] = []
-    private(set) var errorMessage: String?
+    private(set) var loadErrorMessage: String?
+    private(set) var mutationErrorMessage: String?
 
     private(set) var isLoading = false
     private(set) var isAdding = false
@@ -84,11 +85,11 @@ final class ItemsViewModel {
         do {
             let item = try await api.createItem(categoryID: validated.categoryID, name: validated.name)
             items.append(item)
-            errorMessage = nil
+            mutationErrorMessage = nil
             applyFilters()
             return true
         } catch {
-            errorMessage = errorDescription(error)
+            mutationErrorMessage = errorDescription(error)
             return false
         }
     }
@@ -118,11 +119,11 @@ final class ItemsViewModel {
             if let index = items.firstIndex(where: { $0.id == id }) {
                 items[index] = updated
             }
-            errorMessage = nil
+            mutationErrorMessage = nil
             applyFilters()
             return true
         } catch {
-            errorMessage = errorDescription(error)
+            mutationErrorMessage = errorDescription(error)
             return false
         }
     }
@@ -135,11 +136,11 @@ final class ItemsViewModel {
         do {
             try await api.deleteItem(id: id)
             items.removeAll(where: { $0.id == id })
-            errorMessage = nil
+            mutationErrorMessage = nil
             applyFilters()
             return true
         } catch {
-            errorMessage = errorDescription(error)
+            mutationErrorMessage = errorDescription(error)
             return false
         }
     }
@@ -159,7 +160,7 @@ final class ItemsViewModel {
             }
 
             items = try await api.listItems(inList: nil)
-            errorMessage = nil
+            mutationErrorMessage = nil
             applyFilters()
 
             notificationCenter.post(
@@ -173,7 +174,7 @@ final class ItemsViewModel {
             )
             return true
         } catch {
-            errorMessage = errorDescription(error)
+            mutationErrorMessage = errorDescription(error)
             return false
         }
     }
@@ -200,11 +201,11 @@ final class ItemsViewModel {
 
             categories = fetchedCategories
             items = fetchedItems
-            errorMessage = nil
+            loadErrorMessage = nil
             applyFilters()
         } catch {
             guard loadID == latestLoadID else { return }
-            errorMessage = errorDescription(error)
+            loadErrorMessage = errorDescription(error)
         }
     }
 
@@ -228,11 +229,11 @@ final class ItemsViewModel {
     private func validatedInput(name: String, categoryID: Int?) -> (name: String, categoryID: Int)? {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty else {
-            errorMessage = "Item name is required."
+            mutationErrorMessage = "Item name is required."
             return nil
         }
         guard let categoryID else {
-            errorMessage = "Category is required."
+            mutationErrorMessage = "Category is required."
             return nil
         }
         return (name: trimmedName, categoryID: categoryID)

--- a/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift
@@ -104,9 +104,14 @@ final class ItemsViewModel {
             return false
         }
         guard !isUpdating else { return false }
+        guard !mutatingItemIDs.contains(id) else { return false }
 
         isUpdating = true
-        defer { isUpdating = false }
+        mutatingItemIDs.insert(id)
+        defer {
+            isUpdating = false
+            mutatingItemIDs.remove(id)
+        }
 
         do {
             let updated = try await api.updateItem(id: id, categoryID: validated.categoryID, name: validated.name)

--- a/clients/ios/Sources/Groceries/Features/Navigation/AppTabsView.swift
+++ b/clients/ios/Sources/Groceries/Features/Navigation/AppTabsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 enum AppTab: String, CaseIterable, Hashable {
     case list
+    case items
     case account
 }
 
@@ -32,6 +33,12 @@ struct AppTabsView: View {
                     Label("List", systemImage: "cart")
                 }
                 .tag(AppTab.list)
+
+            ItemsView(apiClient: authViewModel.apiClient)
+                .tabItem {
+                    Label("Items", systemImage: "square.grid.2x2")
+                }
+                .tag(AppTab.items)
 
             AccountView()
                 .tabItem {

--- a/clients/ios/Sources/Groceries/Features/ShoppingList/ShoppingListView.swift
+++ b/clients/ios/Sources/Groceries/Features/ShoppingList/ShoppingListView.swift
@@ -41,7 +41,8 @@ struct ShoppingListView: View {
     @State private var showFinishConfirmation: Bool = false
     @State private var selectedStoreID: Int?
     @State private var autoRefreshCoordinator = ShoppingListAutoRefreshCoordinator()
-    @State private var isRefreshingList = false
+    @State private var refreshRequestGate = ShoppingListRefreshRequestGate()
+    @State private var membershipRefreshObserver = ShoppingListMembershipRefreshObserver()
 
     // MARK: - Init
 
@@ -82,7 +83,16 @@ struct ShoppingListView: View {
             ) { _ in
                 handleDidBecomeActive()
             }
-            .onAppear { reconcileStoreSelection() }
+            .onAppear {
+                reconcileStoreSelection()
+                membershipRefreshObserver.start {
+                    Task { @MainActor in
+                        requestAutoRefresh(trigger: .membershipChanged)
+                    }
+                }
+                requestAutoRefresh(trigger: .onAppear)
+            }
+            .onDisappear { membershipRefreshObserver.stop() }
             .onChange(of: viewModel.hasInFlightListMutation) { _, isBusy in
                 handleMutationStateChange(isBusy: isBusy)
             }
@@ -306,23 +316,35 @@ struct ShoppingListView: View {
             isBusy: viewModel.hasInFlightListMutation
         )
         if action == .refreshNow {
-            Task { await refreshIfNeeded() }
+            requestAutoRefresh(trigger: .appDidBecomeActive)
         }
     }
 
     private func handleMutationStateChange(isBusy: Bool) {
         let action = autoRefreshCoordinator.mutationStateDidChange(isBusy: isBusy)
         if action == .refreshNow {
-            Task { await refreshIfNeeded() }
+            requestAutoRefresh(trigger: .mutationBecameIdle)
+        }
+    }
+
+    private func requestAutoRefresh(trigger: ShoppingListRefreshRequestGate.Trigger) {
+        guard refreshRequestGate.shouldStartRefresh(trigger: trigger) else {
+            return
+        }
+
+        Task {
+            await runRefresh()
         }
     }
 
     private func refreshIfNeeded() async {
-        guard !isRefreshingList else { return }
+        guard refreshRequestGate.shouldStartRefresh(trigger: .pullToRefresh) else { return }
 
-        isRefreshingList = true
-        defer { isRefreshingList = false }
+        await runRefresh()
+    }
 
+    private func runRefresh() async {
+        defer { refreshRequestGate.refreshCompleted() }
         await viewModel.refresh()
     }
 
@@ -388,6 +410,77 @@ struct ShoppingListView: View {
 
     private func doneItemWord(for count: Int) -> String {
         count == 1 ? "item" : "items"
+    }
+}
+
+struct ShoppingListRefreshRequestGate {
+    enum Trigger {
+        case onAppear
+        case appDidBecomeActive
+        case membershipChanged
+        case mutationBecameIdle
+        case pullToRefresh
+    }
+
+    private let dedupeWindow: TimeInterval
+    private(set) var isRefreshInFlight = false
+    private var lastRefreshRequestAt: Date?
+
+    init(dedupeWindow: TimeInterval = 0.3) {
+        self.dedupeWindow = dedupeWindow
+    }
+
+    mutating func shouldStartRefresh(trigger: Trigger, now: Date = Date()) -> Bool {
+        _ = trigger
+
+        guard !isRefreshInFlight else {
+            return false
+        }
+
+        if let lastRefreshRequestAt,
+            now.timeIntervalSince(lastRefreshRequestAt) < dedupeWindow
+        {
+            return false
+        }
+
+        isRefreshInFlight = true
+        self.lastRefreshRequestAt = now
+        return true
+    }
+
+    mutating func refreshCompleted() {
+        isRefreshInFlight = false
+    }
+}
+
+final class ShoppingListMembershipRefreshObserver {
+    private let notificationCenter: NotificationCenter
+    private var token: NSObjectProtocol?
+
+    init(notificationCenter: NotificationCenter = .default) {
+        self.notificationCenter = notificationCenter
+    }
+
+    deinit {
+        stop()
+    }
+
+    func start(onMembershipChanged: @escaping @Sendable () -> Void) {
+        guard token == nil else { return }
+
+        token = notificationCenter.addObserver(
+            forName: AppEvents.MembershipChanged.name,
+            object: nil,
+            queue: .main
+        ) { _ in
+            onMembershipChanged()
+        }
+    }
+
+    func stop() {
+        guard let token else { return }
+        notificationCenter.removeObserver(token)
+        self.token = nil
     }
 }
 

--- a/clients/ios/Sources/Groceries/Shared/AppEvents.swift
+++ b/clients/ios/Sources/Groceries/Shared/AppEvents.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum AppEvents {
+    enum MembershipChanged {
+        static let name = Notification.Name("itemsMembershipDidChange")
+        static let itemIDKey = "itemID"
+        static let isInListKey = "isInList"
+        static let changedAtKey = "changedAt"
+    }
+}

--- a/clients/ios/Sources/GroceriesAPI/ItemEndpoints.swift
+++ b/clients/ios/Sources/GroceriesAPI/ItemEndpoints.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+// MARK: - Item endpoints
+
+extension GroceriesAPIClient {
+
+    /// Returns all items, optionally filtered by category and list membership.
+    public func listItems(categoryID: Int? = nil, inList: Bool? = nil) async throws -> [Item] {
+        var queryItems: [URLQueryItem] = []
+
+        if let categoryID {
+            queryItems.append(URLQueryItem(name: "category_id", value: String(categoryID)))
+        }
+
+        if let inList {
+            queryItems.append(URLQueryItem(name: "in_list", value: inList ? "true" : "false"))
+        }
+
+        let req = try request(
+            method: "GET",
+            path: "/api/v1/items",
+            queryItems: queryItems.isEmpty ? nil : queryItems
+        )
+        return try await perform(req)
+    }
+
+    /// Creates a new grocery item.
+    public func createItem(categoryID: Int, name: String) async throws -> Item {
+        let body = CreateItemRequest(categoryID: categoryID, name: name)
+        let req = try request(method: "POST", path: "/api/v1/items", body: body)
+        return try await perform(req)
+    }
+
+    /// Updates an existing grocery item.
+    public func updateItem(id: Int, categoryID: Int, name: String) async throws -> Item {
+        let body = UpdateItemRequest(categoryID: categoryID, name: name)
+        let req = try request(method: "PUT", path: "/api/v1/items/\(id)", body: body)
+        return try await perform(req)
+    }
+
+    /// Deletes a grocery item.
+    public func deleteItem(id: Int) async throws {
+        let req = try request(method: "DELETE", path: "/api/v1/items/\(id)")
+        try await performVoid(req)
+    }
+}

--- a/clients/ios/Sources/GroceriesAPI/Models.swift
+++ b/clients/ios/Sources/GroceriesAPI/Models.swift
@@ -65,6 +65,14 @@ public struct Item: Decodable, Identifiable, Sendable {
     /// Present when this item is currently on the shopping list.
     public let list: ListItemSummary?
 
+    public init(id: Int, categoryID: Int, categoryName: String, name: String, list: ListItemSummary?) {
+        self.id = id
+        self.categoryID = categoryID
+        self.categoryName = categoryName
+        self.name = name
+        self.list = list
+    }
+
     enum CodingKeys: String, CodingKey {
         case id
         case categoryID = "category_id"
@@ -112,6 +120,12 @@ public struct ListItemSummary: Decodable, Identifiable, Sendable {
     public let id: Int
     public let quantity: String
     public let done: Bool
+
+    public init(id: Int, quantity: String, done: Bool) {
+        self.id = id
+        self.quantity = quantity
+        self.done = done
+    }
 }
 
 /// A full list entry as returned by `GET /api/v1/list`.

--- a/clients/ios/Sources/GroceriesAPI/Models.swift
+++ b/clients/ios/Sources/GroceriesAPI/Models.swift
@@ -74,6 +74,36 @@ public struct Item: Decodable, Identifiable, Sendable {
     }
 }
 
+public struct CreateItemRequest: Encodable, Sendable {
+    public let categoryID: Int
+    public let name: String
+
+    public init(categoryID: Int, name: String) {
+        self.categoryID = categoryID
+        self.name = name
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case categoryID = "category_id"
+        case name
+    }
+}
+
+public struct UpdateItemRequest: Encodable, Sendable {
+    public let categoryID: Int
+    public let name: String
+
+    public init(categoryID: Int, name: String) {
+        self.categoryID = categoryID
+        self.name = name
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case categoryID = "category_id"
+        case name
+    }
+}
+
 // MARK: - Shopping List
 
 /// A lightweight summary of a list entry embedded inside an `Item`.

--- a/clients/ios/Tests/GroceriesAPITests/GroceriesAPIClientTests.swift
+++ b/clients/ios/Tests/GroceriesAPITests/GroceriesAPIClientTests.swift
@@ -350,6 +350,252 @@ final class GroceriesAPIClientTests: XCTestCase {
         XCTAssertEqual(items[1].name, "Bread")
     }
 
+    func testListItems_withInListQueryEncodesQueryItem() async throws {
+        let responseJSON = """
+            [
+                {
+                    "id": 1,
+                    "category_id": 10,
+                    "category_name": "Produce",
+                    "name": "Apples"
+                }
+            ]
+            """
+
+        MockURLProtocol.setRequestHandler { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/v1/items")
+
+            let queryItems = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.queryItems
+            XCTAssertEqual(queryItems?.count, 1)
+            XCTAssertEqual(queryItems?.first?.name, "in_list")
+            XCTAssertEqual(queryItems?.first?.value, "true")
+
+            let data = try XCTUnwrap(responseJSON.data(using: .utf8))
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+
+            return (response, data)
+        }
+
+        let client = makeClient()
+        let items = try await client.listItems(inList: true)
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].name, "Apples")
+    }
+
+    func testCreateItem_postsExpectedBody() async throws {
+        let responseJSON = """
+            {
+                "id": 21,
+                "category_id": 4,
+                "category_name": "Bakery",
+                "name": "Bagels"
+            }
+            """
+
+        MockURLProtocol.setRequestHandler { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.path, "/api/v1/items")
+
+            let body = try XCTUnwrap(MockURLProtocol.requestBodyData(from: request))
+            let bodyString = try XCTUnwrap(String(data: body, encoding: .utf8))
+            XCTAssertTrue(bodyString.contains("\"category_id\":4"))
+            XCTAssertTrue(bodyString.contains("\"name\":\"Bagels\""))
+
+            let data = try XCTUnwrap(responseJSON.data(using: .utf8))
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+
+            return (response, data)
+        }
+
+        let client = makeClient()
+        let item = try await client.createItem(categoryID: 4, name: "Bagels")
+
+        XCTAssertEqual(item.id, 21)
+        XCTAssertEqual(item.name, "Bagels")
+        XCTAssertEqual(item.categoryID, 4)
+    }
+
+    func testUpdateItem_putsExpectedBody() async throws {
+        let responseJSON = """
+            {
+                "id": 21,
+                "category_id": 5,
+                "category_name": "Pantry",
+                "name": "Granola"
+            }
+            """
+
+        MockURLProtocol.setRequestHandler { request in
+            XCTAssertEqual(request.httpMethod, "PUT")
+            XCTAssertEqual(request.url?.path, "/api/v1/items/21")
+
+            let body = try XCTUnwrap(MockURLProtocol.requestBodyData(from: request))
+            let bodyString = try XCTUnwrap(String(data: body, encoding: .utf8))
+            XCTAssertTrue(bodyString.contains("\"category_id\":5"))
+            XCTAssertTrue(bodyString.contains("\"name\":\"Granola\""))
+
+            let data = try XCTUnwrap(responseJSON.data(using: .utf8))
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+
+            return (response, data)
+        }
+
+        let client = makeClient()
+        let item = try await client.updateItem(id: 21, categoryID: 5, name: "Granola")
+
+        XCTAssertEqual(item.id, 21)
+        XCTAssertEqual(item.name, "Granola")
+        XCTAssertEqual(item.categoryID, 5)
+    }
+
+    func testDeleteItem_sendsDelete() async throws {
+        MockURLProtocol.setRequestHandler { request in
+            XCTAssertEqual(request.httpMethod, "DELETE")
+            XCTAssertEqual(request.url?.path, "/api/v1/items/21")
+
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 204,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+
+            return (response, Data())
+        }
+
+        let client = makeClient()
+        try await client.deleteItem(id: 21)
+    }
+
+    func testDeleteItem_conflict_throws409() async throws {
+        MockURLProtocol.setRequestHandler { request in
+            XCTAssertEqual(request.httpMethod, "DELETE")
+            XCTAssertEqual(request.url?.path, "/api/v1/items/21")
+
+            let data = try XCTUnwrap("{\"error\":\"item is on the shopping list\"}".data(using: .utf8))
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 409,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+
+            return (response, data)
+        }
+
+        let client = makeClient()
+
+        do {
+            try await client.deleteItem(id: 21)
+            XCTFail("Expected conflict error")
+        } catch let error as APIError {
+            switch error {
+            case .conflict(let message):
+                XCTAssertEqual(message, "item is on the shopping list")
+            default:
+                XCTFail("Expected APIError.conflict, got \(error)")
+            }
+        }
+    }
+
+    func testUpdateItem_notFound_throws404() async throws {
+        MockURLProtocol.setRequestHandler { request in
+            XCTAssertEqual(request.httpMethod, "PUT")
+            XCTAssertEqual(request.url?.path, "/api/v1/items/999")
+
+            let body = try XCTUnwrap(MockURLProtocol.requestBodyData(from: request))
+            let bodyString = try XCTUnwrap(String(data: body, encoding: .utf8))
+            XCTAssertTrue(bodyString.contains("\"category_id\":5"))
+            XCTAssertTrue(bodyString.contains("\"name\":\"Granola\""))
+
+            let data = try XCTUnwrap("{\"error\":\"item not found\"}".data(using: .utf8))
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+
+            return (response, data)
+        }
+
+        let client = makeClient()
+
+        do {
+            _ = try await client.updateItem(id: 999, categoryID: 5, name: "Granola")
+            XCTFail("Expected notFound error")
+        } catch let error as APIError {
+            switch error {
+            case .notFound(let message):
+                XCTAssertEqual(message, "item not found")
+            default:
+                XCTFail("Expected APIError.notFound, got \(error)")
+            }
+        }
+    }
+
+    func testDeleteItem_notFound_throws404() async throws {
+        MockURLProtocol.setRequestHandler { request in
+            XCTAssertEqual(request.httpMethod, "DELETE")
+            XCTAssertEqual(request.url?.path, "/api/v1/items/999")
+
+            let data = try XCTUnwrap("{\"error\":\"item not found\"}".data(using: .utf8))
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+
+            return (response, data)
+        }
+
+        let client = makeClient()
+
+        do {
+            try await client.deleteItem(id: 999)
+            XCTFail("Expected notFound error")
+        } catch let error as APIError {
+            switch error {
+            case .notFound(let message):
+                XCTAssertEqual(message, "item not found")
+            default:
+                XCTFail("Expected APIError.notFound, got \(error)")
+            }
+        }
+    }
+
     func testAddItemToList_existingItem() async throws {
         let responseJSON = """
             {

--- a/clients/ios/Tests/GroceriesAPITests/GroceriesAPIClientTests.swift
+++ b/clients/ios/Tests/GroceriesAPITests/GroceriesAPIClientTests.swift
@@ -205,6 +205,26 @@ final class GroceriesAPIClientTests: XCTestCase {
         XCTAssertFalse(json.contains("\"quantity\""))
     }
 
+    func testEncodeCreateItemRequest() throws {
+        let request = CreateItemRequest(categoryID: 7, name: "Apples")
+        let data = try JSONEncoder.apiEncoder.encode(request)
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertTrue(json.contains("\"category_id\":7"))
+        XCTAssertTrue(json.contains("\"name\":\"Apples\""))
+        XCTAssertFalse(json.contains("\"categoryID\""))
+    }
+
+    func testEncodeUpdateItemRequest() throws {
+        let request = UpdateItemRequest(categoryID: 4, name: "Bread")
+        let data = try JSONEncoder.apiEncoder.encode(request)
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertTrue(json.contains("\"category_id\":4"))
+        XCTAssertTrue(json.contains("\"name\":\"Bread\""))
+        XCTAssertFalse(json.contains("\"categoryID\""))
+    }
+
     // MARK: - APIError descriptions
 
     func testAPIErrorUnauthorizedDescription() {

--- a/clients/ios/Tests/GroceriesAPITests/GroceriesAPIClientTests.swift
+++ b/clients/ios/Tests/GroceriesAPITests/GroceriesAPIClientTests.swift
@@ -4,6 +4,13 @@ import XCTest
 
 // MARK: - GroceriesAPIClientTests
 
+private enum TestJSONHelper {
+    static func jsonObject(from body: Data) throws -> [String: Any] {
+        let object = try JSONSerialization.jsonObject(with: body)
+        return try XCTUnwrap(object as? [String: Any])
+    }
+}
+
 final class GroceriesAPIClientTests: XCTestCase {
 
     override func tearDown() {
@@ -391,6 +398,131 @@ final class GroceriesAPIClientTests: XCTestCase {
         XCTAssertEqual(items[0].name, "Apples")
     }
 
+    func testListItems_withCategoryIDQueryEncodesCategoryIDOnly() async throws {
+        let responseJSON = """
+            [
+                {
+                    "id": 3,
+                    "category_id": 10,
+                    "category_name": "Produce",
+                    "name": "Carrots"
+                }
+            ]
+            """
+
+        MockURLProtocol.setRequestHandler { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/v1/items")
+
+            let queryItems = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.queryItems
+            XCTAssertEqual(queryItems?.count, 1)
+            XCTAssertEqual(queryItems?.first?.name, "category_id")
+            XCTAssertEqual(queryItems?.first?.value, "10")
+
+            let data = try XCTUnwrap(responseJSON.data(using: .utf8))
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+
+            return (response, data)
+        }
+
+        let client = makeClient()
+        let items = try await client.listItems(categoryID: 10)
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].name, "Carrots")
+    }
+
+    func testListItems_withInListFalseQueryEncodesFalse() async throws {
+        let responseJSON = """
+            [
+                {
+                    "id": 4,
+                    "category_id": 12,
+                    "category_name": "Pantry",
+                    "name": "Pasta"
+                }
+            ]
+            """
+
+        MockURLProtocol.setRequestHandler { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/v1/items")
+
+            let queryItems = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.queryItems
+            XCTAssertEqual(queryItems?.count, 1)
+            XCTAssertEqual(queryItems?.first?.name, "in_list")
+            XCTAssertEqual(queryItems?.first?.value, "false")
+
+            let data = try XCTUnwrap(responseJSON.data(using: .utf8))
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+
+            return (response, data)
+        }
+
+        let client = makeClient()
+        let items = try await client.listItems(inList: false)
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].name, "Pasta")
+    }
+
+    func testListItems_withCategoryIDAndInListQueryEncodesBothItems() async throws {
+        let responseJSON = """
+            [
+                {
+                    "id": 5,
+                    "category_id": 2,
+                    "category_name": "Dairy",
+                    "name": "Yogurt"
+                }
+            ]
+            """
+
+        MockURLProtocol.setRequestHandler { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/v1/items")
+
+            let queryItems = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.queryItems ?? []
+            XCTAssertEqual(queryItems.count, 2)
+
+            let queryByName = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
+            XCTAssertEqual(queryByName["category_id"], "2")
+            XCTAssertEqual(queryByName["in_list"], "false")
+
+            let data = try XCTUnwrap(responseJSON.data(using: .utf8))
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+
+            return (response, data)
+        }
+
+        let client = makeClient()
+        let items = try await client.listItems(categoryID: 2, inList: false)
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0].name, "Yogurt")
+    }
+
     func testCreateItem_postsExpectedBody() async throws {
         let responseJSON = """
             {
@@ -406,9 +538,10 @@ final class GroceriesAPIClientTests: XCTestCase {
             XCTAssertEqual(request.url?.path, "/api/v1/items")
 
             let body = try XCTUnwrap(MockURLProtocol.requestBodyData(from: request))
-            let bodyString = try XCTUnwrap(String(data: body, encoding: .utf8))
-            XCTAssertTrue(bodyString.contains("\"category_id\":4"))
-            XCTAssertTrue(bodyString.contains("\"name\":\"Bagels\""))
+            let payload = try TestJSONHelper.jsonObject(from: body)
+            XCTAssertEqual(payload["category_id"] as? Int, 4)
+            XCTAssertEqual(payload["name"] as? String, "Bagels")
+            XCTAssertNil(payload["categoryID"])
 
             let data = try XCTUnwrap(responseJSON.data(using: .utf8))
             let response = try XCTUnwrap(
@@ -446,9 +579,10 @@ final class GroceriesAPIClientTests: XCTestCase {
             XCTAssertEqual(request.url?.path, "/api/v1/items/21")
 
             let body = try XCTUnwrap(MockURLProtocol.requestBodyData(from: request))
-            let bodyString = try XCTUnwrap(String(data: body, encoding: .utf8))
-            XCTAssertTrue(bodyString.contains("\"category_id\":5"))
-            XCTAssertTrue(bodyString.contains("\"name\":\"Granola\""))
+            let payload = try TestJSONHelper.jsonObject(from: body)
+            XCTAssertEqual(payload["category_id"] as? Int, 5)
+            XCTAssertEqual(payload["name"] as? String, "Granola")
+            XCTAssertNil(payload["categoryID"])
 
             let data = try XCTUnwrap(responseJSON.data(using: .utf8))
             let response = try XCTUnwrap(
@@ -531,9 +665,9 @@ final class GroceriesAPIClientTests: XCTestCase {
             XCTAssertEqual(request.url?.path, "/api/v1/items/999")
 
             let body = try XCTUnwrap(MockURLProtocol.requestBodyData(from: request))
-            let bodyString = try XCTUnwrap(String(data: body, encoding: .utf8))
-            XCTAssertTrue(bodyString.contains("\"category_id\":5"))
-            XCTAssertTrue(bodyString.contains("\"name\":\"Granola\""))
+            let payload = try TestJSONHelper.jsonObject(from: body)
+            XCTAssertEqual(payload["category_id"] as? Int, 5)
+            XCTAssertEqual(payload["name"] as? String, "Granola")
 
             let data = try XCTUnwrap("{\"error\":\"item not found\"}".data(using: .utf8))
             let response = try XCTUnwrap(

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewLayerTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewLayerTests.swift
@@ -1,9 +1,88 @@
 import XCTest
+import GroceriesAPI
 
 @testable import Aisle4
 
 @MainActor
 final class ItemsViewLayerTests: XCTestCase {
+    func test_itemSelectionRoutesToEditorByItemID() throws {
+        let item = try makeItem(
+            """
+            {
+              "id": 42,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+
+        let route = ItemsViewUX.editorRoute(for: item)
+
+        XCTAssertEqual(route, .editor(itemID: 42))
+    }
+
+    func test_editorRouteResolvesToExistingItem() throws {
+        let item = try makeItem(
+            """
+            {
+              "id": 8,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Yogurt"
+            }
+            """
+        )
+
+        let route = ItemsViewRoute.editor(itemID: 8)
+
+        XCTAssertEqual(ItemsViewUX.editorItem(for: route, items: [item])?.id, 8)
+    }
+
+    func test_membershipToggleAccess_isEditorOnly() {
+        XCTAssertFalse(ItemMembershipToggleAccess.isAvailable(in: .listRows))
+        XCTAssertFalse(ItemMembershipToggleAccess.isAvailable(in: .addItemForm))
+        XCTAssertTrue(ItemMembershipToggleAccess.isAvailable(in: .editor))
+    }
+
+    func test_retryAffordance_visibleOnlyWhenLoadFailedAndListEmpty() {
+        let item = try! makeItem(
+            """
+            {
+              "id": 1,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+
+        XCTAssertTrue(
+            ItemsViewUX.shouldShowRetryAffordance(
+                isLoading: false,
+                filteredItems: [],
+                errorMessage: "boom"
+            )
+        )
+
+        XCTAssertFalse(
+            ItemsViewUX.shouldShowRetryAffordance(
+                isLoading: false,
+                filteredItems: [item],
+                errorMessage: "boom"
+            )
+        )
+    }
+
+    func test_retryAffordanceAction_invokesRetryLoadPath() async {
+        let recorder = RetryActionRecorder()
+
+        await ItemsViewUX.performRetry(using: recorder.record)
+
+        let count = await recorder.count
+        XCTAssertEqual(count, 1)
+    }
+
     func test_addFlowControlsDisabled_whileAdding() {
         XCTAssertTrue(AddItemViewUX.cancelDisabled(isAdding: true))
         XCTAssertTrue(AddItemViewUX.saveDisabled(isAdding: true, baseSaveDisabled: false))
@@ -73,5 +152,18 @@ final class ItemsViewLayerTests: XCTestCase {
         )
 
         XCTAssertTrue(synced)
+    }
+}
+
+private func makeItem(_ json: String) throws -> Item {
+    let data = try XCTUnwrap(json.data(using: .utf8))
+    return try JSONDecoder().decode(Item.self, from: data)
+}
+
+private actor RetryActionRecorder {
+    private(set) var count = 0
+
+    func record() async {
+        count += 1
     }
 }

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewLayerTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewLayerTests.swift
@@ -26,4 +26,52 @@ final class ItemsViewLayerTests: XCTestCase {
         XCTAssertEqual(AddItemViewAccessibility.saveButtonLabel, "Save item")
         XCTAssertEqual(AddItemViewAccessibility.errorLabel, "Add item error")
     }
+
+    func test_itemEditorMembershipToggle_pessimisticFlow_keepsVisibleValueUntilSuccess() {
+        let initial = ItemEditorViewUX.membershipToggleInitialState(isInList: false)
+
+        XCTAssertEqual(initial.visibleValue, false)
+
+        let afterTap = ItemEditorViewUX.membershipToggleBeginMutation(
+            currentVisibleValue: initial.visibleValue,
+            requestedValue: true
+        )
+
+        XCTAssertEqual(afterTap.visibleValue, false)
+        XCTAssertEqual(afterTap.requestedValue, true)
+
+        let afterSuccess = ItemEditorViewUX.membershipToggleResolveMutation(
+            currentVisibleValue: afterTap.visibleValue,
+            requestedValue: afterTap.requestedValue,
+            success: true
+        )
+
+        XCTAssertEqual(afterSuccess, true)
+    }
+
+    func test_itemEditorMembershipToggle_notFoundFailure_keepsVisibleValue() {
+        let afterTap = ItemEditorViewUX.membershipToggleBeginMutation(
+            currentVisibleValue: true,
+            requestedValue: false
+        )
+
+        let afterFailure = ItemEditorViewUX.membershipToggleResolveMutation(
+            currentVisibleValue: afterTap.visibleValue,
+            requestedValue: afterTap.requestedValue,
+            success: false
+        )
+
+        XCTAssertEqual(afterTap.visibleValue, true)
+        XCTAssertEqual(afterFailure, true)
+    }
+
+    func test_itemEditorMembershipToggle_syncsToExternalModelMembershipChange() {
+        let synced = ItemEditorViewUX.membershipToggleSyncExternalModelChange(
+            currentVisibleValue: false,
+            modelIsInList: true,
+            isMutationInFlight: false
+        )
+
+        XCTAssertTrue(synced)
+    }
 }

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewLayerTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewLayerTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+@testable import Aisle4
+
+@MainActor
+final class ItemsViewLayerTests: XCTestCase {
+    func test_addFlowControlsDisabled_whileAdding() {
+        XCTAssertTrue(AddItemViewUX.cancelDisabled(isAdding: true))
+        XCTAssertTrue(AddItemViewUX.saveDisabled(isAdding: true, baseSaveDisabled: false))
+        XCTAssertTrue(AddItemViewUX.categoryDisabled(isAdding: true))
+        XCTAssertTrue(AddItemViewUX.nameDisabled(isAdding: true))
+    }
+
+    func test_interactiveDismissDisabled_whileAdding() {
+        XCTAssertTrue(ItemsViewUX.addSheetInteractiveDismissDisabled(isAdding: true))
+    }
+
+    func test_accessibilityLabels_remainStable() {
+        XCTAssertEqual(ItemsViewAccessibility.searchFieldLabel, "Item search")
+        XCTAssertEqual(ItemsViewAccessibility.inListOnlyToggleLabel, "In List only")
+        XCTAssertEqual(ItemsViewAccessibility.addItemButtonLabel, "Add item")
+
+        XCTAssertEqual(AddItemViewAccessibility.categoryLabel, "Item category")
+        XCTAssertEqual(AddItemViewAccessibility.nameLabel, "Item name")
+        XCTAssertEqual(AddItemViewAccessibility.cancelButtonLabel, "Cancel add item")
+        XCTAssertEqual(AddItemViewAccessibility.saveButtonLabel, "Save item")
+        XCTAssertEqual(AddItemViewAccessibility.errorLabel, "Add item error")
+    }
+}

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewLayerTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewLayerTests.swift
@@ -5,6 +5,10 @@ import GroceriesAPI
 
 @MainActor
 final class ItemsViewLayerTests: XCTestCase {
+    func test_itemSelectionNavigation_isNotPathDriven() {
+        XCTAssertFalse(ItemsViewUX.shouldUsePathDrivenNavigation())
+    }
+
     func test_itemSelectionRoutesToEditorByItemID() throws {
         let item = try makeItem(
             """

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewLayerTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewLayerTests.swift
@@ -61,7 +61,8 @@ final class ItemsViewLayerTests: XCTestCase {
             ItemsViewUX.shouldShowRetryAffordance(
                 isLoading: false,
                 filteredItems: [],
-                errorMessage: "boom"
+                loadErrorMessage: "boom",
+                mutationErrorMessage: nil
             )
         )
 
@@ -69,7 +70,19 @@ final class ItemsViewLayerTests: XCTestCase {
             ItemsViewUX.shouldShowRetryAffordance(
                 isLoading: false,
                 filteredItems: [item],
-                errorMessage: "boom"
+                loadErrorMessage: "boom",
+                mutationErrorMessage: nil
+            )
+        )
+    }
+
+    func test_retryAffordance_hiddenWhenOnlyMutationErrorExistsAndFiltersEmptyList() {
+        XCTAssertFalse(
+            ItemsViewUX.shouldShowRetryAffordance(
+                isLoading: false,
+                filteredItems: [],
+                loadErrorMessage: nil,
+                mutationErrorMessage: "Category is required."
             )
         )
     }

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
@@ -454,6 +454,104 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertEqual(userInfo[AppEvents.MembershipChanged.isInListKey] as? Bool, false)
     }
 
+    func test_setInListToggleOn_refreshFailure_stillSucceedsPostsNotificationAndUpdatesLocalState() async throws {
+        let notificationCenter = NotificationCenter()
+        let original = try decodeItem(
+            """
+            {
+              "id": 1,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+        let inListItem = try decodeItem(
+            """
+            {
+              "id": 1,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk",
+              "list": { "id": 22, "quantity": "1", "done": false }
+            }
+            """
+        )
+
+        let api = MockItemsAPI(categories: [], items: [original])
+        api.listItemsAfterSetInList = [inListItem]
+        api.listItemsErrorByCall[2] = APIError.serverError("refresh fail")
+
+        let viewModel = ItemsViewModel(api: api, notificationCenter: notificationCenter)
+        await viewModel.load()
+
+        let recorder = NotificationRecorder()
+        let token = notificationCenter.addObserver(
+            forName: AppEvents.MembershipChanged.name,
+            object: nil,
+            queue: nil
+        ) { note in
+            recorder.record(note)
+        }
+        defer { notificationCenter.removeObserver(token) }
+
+        let result = await viewModel.setInList(itemID: 1, isInList: true)
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(api.addItemToListCallCount, 1)
+        XCTAssertEqual(api.listItemsCallCount, 2)
+        XCTAssertNotNil(viewModel.items.first?.list)
+        XCTAssertEqual(recorder.count, 1)
+
+        let notification = try XCTUnwrap(recorder.lastNotification)
+        let userInfo = try XCTUnwrap(notification.userInfo)
+        XCTAssertEqual(userInfo[AppEvents.MembershipChanged.itemIDKey] as? Int, 1)
+        XCTAssertEqual(userInfo[AppEvents.MembershipChanged.isInListKey] as? Bool, true)
+    }
+
+    func test_setInListToggleOff_refreshFailure_stillSucceedsPostsNotificationAndUpdatesLocalState() async throws {
+        let notificationCenter = NotificationCenter()
+        let original = try decodeItem(
+            """
+            {
+              "id": 1,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk",
+              "list": { "id": 22, "quantity": "1", "done": false }
+            }
+            """
+        )
+        let api = MockItemsAPI(categories: [], items: [original])
+        api.listItemsErrorByCall[2] = APIError.serverError("refresh fail")
+
+        let viewModel = ItemsViewModel(api: api, notificationCenter: notificationCenter)
+        await viewModel.load()
+
+        let recorder = NotificationRecorder()
+        let token = notificationCenter.addObserver(
+            forName: AppEvents.MembershipChanged.name,
+            object: nil,
+            queue: nil
+        ) { note in
+            recorder.record(note)
+        }
+        defer { notificationCenter.removeObserver(token) }
+
+        let result = await viewModel.setInList(itemID: 1, isInList: false)
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(api.removeItemFromListCallCount, 1)
+        XCTAssertEqual(api.listItemsCallCount, 2)
+        XCTAssertNil(viewModel.items.first?.list)
+        XCTAssertEqual(recorder.count, 1)
+
+        let notification = try XCTUnwrap(recorder.lastNotification)
+        let userInfo = try XCTUnwrap(notification.userInfo)
+        XCTAssertEqual(userInfo[AppEvents.MembershipChanged.itemIDKey] as? Int, 1)
+        XCTAssertEqual(userInfo[AppEvents.MembershipChanged.isInListKey] as? Bool, false)
+    }
+
     func test_setInListToggleOffFailure_preservesStateAndDoesNotPostNotification() async throws {
         let notificationCenter = NotificationCenter()
         let original = try decodeItem(
@@ -1210,6 +1308,7 @@ private final class MockItemsAPI: ItemsAPI {
 
     var listCategoriesError: Error?
     var listItemsError: Error?
+    var listItemsErrorByCall: [Int: Error] = [:]
     var createItemError: Error?
     var updateItemError: Error?
     var deleteItemError: Error?
@@ -1265,6 +1364,10 @@ private final class MockItemsAPI: ItemsAPI {
     func listItems(inList: Bool?) async throws -> [Item] {
         listItemsCallCount += 1
         let callIndex = listItemsCallCount
+
+        if let listItemsErrorByCall = listItemsErrorByCall[callIndex] {
+            throw listItemsErrorByCall
+        }
 
         if let listItemsError {
             throw listItemsError

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
@@ -268,7 +268,81 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.items.isEmpty)
     }
 
-    func test_setInListSuccess_postsMembershipNotificationPayloadTypes() async throws {
+    func test_load_forceOverlap_keepsNewestLoadResults() async throws {
+        let staleCategory = try decodeCategory(
+            """
+            {
+              "id": 1,
+              "store_id": 1,
+              "name": "Stale",
+              "description": "",
+              "item_count": 1
+            }
+            """
+        )
+        let freshCategory = try decodeCategory(
+            """
+            {
+              "id": 2,
+              "store_id": 1,
+              "name": "Fresh",
+              "description": "",
+              "item_count": 1
+            }
+            """
+        )
+        let staleItem = try decodeItem(
+            """
+            {
+              "id": 1,
+              "category_id": 1,
+              "category_name": "Stale",
+              "name": "Stale Item"
+            }
+            """
+        )
+        let freshItem = try decodeItem(
+            """
+            {
+              "id": 2,
+              "category_id": 2,
+              "category_name": "Fresh",
+              "name": "Fresh Item"
+            }
+            """
+        )
+
+        let api = MockItemsAPI(categories: [staleCategory], items: [staleItem])
+        api.listItemsResponsesByCall = [
+            1: [staleItem],
+            2: [freshItem],
+        ]
+        api.blockedListItemsCallIndices = [1]
+
+        let parked = expectation(description: "first listItems call parked")
+        api.onListItemsCallParked = { callIndex in
+            if callIndex == 1 {
+                parked.fulfill()
+            }
+        }
+
+        let viewModel = ItemsViewModel(api: api)
+
+        let firstLoad = Task { await viewModel.load() }
+        await fulfillment(of: [parked], timeout: 1.0)
+
+        api.categories = [freshCategory]
+        let forcedRefresh = Task { await viewModel.retryLoad() }
+        await forcedRefresh.value
+
+        api.releaseListItemsCall(1)
+        await firstLoad.value
+
+        XCTAssertEqual(viewModel.items.map(\.name), ["Fresh Item"])
+        XCTAssertEqual(viewModel.categories.map(\.name), ["Fresh"])
+    }
+
+    func test_setInListSuccess_postsMembershipNotificationContract() async throws {
         let notificationCenter = NotificationCenter()
         let api = MockItemsAPI(
             categories: [],
@@ -315,10 +389,16 @@ final class ItemsViewModelTests: XCTestCase {
         let ok = await viewModel.setInList(itemID: 1, isInList: true)
 
         XCTAssertTrue(ok)
-        let userInfo = try XCTUnwrap(recorder.lastUserInfo)
-        XCTAssertTrue(userInfo[AppEvents.MembershipChanged.itemIDKey] is Int)
-        XCTAssertTrue(userInfo[AppEvents.MembershipChanged.isInListKey] is Bool)
-        XCTAssertTrue(userInfo[AppEvents.MembershipChanged.changedAtKey] is Date)
+        XCTAssertEqual(recorder.count, 1)
+
+        let notification = try XCTUnwrap(recorder.lastNotification)
+        XCTAssertEqual(notification.name, AppEvents.MembershipChanged.name)
+        XCTAssertNil(notification.object)
+
+        let userInfo = try XCTUnwrap(notification.userInfo)
+        XCTAssertEqual(userInfo[AppEvents.MembershipChanged.itemIDKey] as? Int, 1)
+        XCTAssertEqual(userInfo[AppEvents.MembershipChanged.isInListKey] as? Bool, true)
+        XCTAssertNotNil(userInfo[AppEvents.MembershipChanged.changedAtKey] as? Date)
     }
 
     func test_toggleAndDeleteFailure_preserveState_andToggleFailureDoesNotPostNotification() async throws {
@@ -371,20 +451,204 @@ final class ItemsViewModelTests: XCTestCase {
             }
             """
         )
-        api.waitForCreate = true
+        api.blockedCreateCallIndices = [1]
+
+        let parked = expectation(description: "create call parked")
+        api.onCreateCallParked = { callIndex in
+            if callIndex == 1 {
+                parked.fulfill()
+            }
+        }
 
         let viewModel = ItemsViewModel(api: api)
 
         let first = Task { await viewModel.addItem(name: "Milk", categoryID: 1) }
-        let second = Task { await viewModel.addItem(name: "Milk", categoryID: 1) }
+        await fulfillment(of: [parked], timeout: 1.0)
 
-        await Task.yield()
-        api.releaseCreateContinuation()
+        let second = Task { await viewModel.addItem(name: "Milk", categoryID: 1) }
+        api.releaseCreateCall(1)
 
         _ = await first.value
         _ = await second.value
 
         XCTAssertEqual(api.createItemCallCount, 1)
+    }
+
+    func test_updateItem_duplicateInFlightCall_isRejected() async throws {
+        let existingItem = try decodeItem(
+            """
+            {
+              "id": 10,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+        let updatedItem = try decodeItem(
+            """
+            {
+              "id": 10,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Oat Milk"
+            }
+            """
+        )
+
+        let api = MockItemsAPI(categories: [], items: [existingItem])
+        api.updateItemResult = updatedItem
+        api.blockedUpdateCallIndices = [1]
+
+        let parked = expectation(description: "update call parked")
+        api.onUpdateCallParked = { callIndex in
+            if callIndex == 1 {
+                parked.fulfill()
+            }
+        }
+
+        let viewModel = ItemsViewModel(api: api)
+
+        let first = Task { await viewModel.updateItem(id: 10, name: "Oat Milk", categoryID: 1) }
+        await fulfillment(of: [parked], timeout: 1.0)
+        let second = Task { await viewModel.updateItem(id: 10, name: "Oat Milk", categoryID: 1) }
+
+        api.releaseUpdateCall(1)
+
+        let firstResult = await first.value
+        let secondResult = await second.value
+
+        XCTAssertTrue(firstResult)
+        XCTAssertFalse(secondResult)
+        XCTAssertEqual(api.updateItemCallCount, 1)
+    }
+
+    func test_deleteItem_duplicateInFlightCall_isRejected() async throws {
+        let item = try decodeItem(
+            """
+            {
+              "id": 7,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Yogurt"
+            }
+            """
+        )
+
+        let api = MockItemsAPI(categories: [], items: [item])
+        api.blockedDeleteCallIndices = [1]
+
+        let parked = expectation(description: "delete call parked")
+        api.onDeleteCallParked = { callIndex in
+            if callIndex == 1 {
+                parked.fulfill()
+            }
+        }
+
+        let viewModel = ItemsViewModel(api: api)
+
+        let first = Task { await viewModel.deleteItem(id: 7) }
+        await fulfillment(of: [parked], timeout: 1.0)
+        let second = Task { await viewModel.deleteItem(id: 7) }
+
+        api.releaseDeleteCall(1)
+
+        let firstResult = await first.value
+        let secondResult = await second.value
+
+        XCTAssertTrue(firstResult)
+        XCTAssertFalse(secondResult)
+        XCTAssertEqual(api.deleteItemCallCount, 1)
+    }
+
+    func test_setInList_duplicateInFlightCall_isRejected() async throws {
+        let item = try decodeItem(
+            """
+            {
+              "id": 5,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Cream"
+            }
+            """
+        )
+        let inListItem = try decodeItem(
+            """
+            {
+              "id": 5,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Cream",
+              "list": { "id": 31, "quantity": "1", "done": false }
+            }
+            """
+        )
+
+        let api = MockItemsAPI(categories: [], items: [item])
+        api.listItemsAfterSetInList = [inListItem]
+        api.blockedAddItemToListCallIndices = [1]
+
+        let parked = expectation(description: "addItemToList call parked")
+        api.onAddItemToListCallParked = { callIndex in
+            if callIndex == 1 {
+                parked.fulfill()
+            }
+        }
+
+        let viewModel = ItemsViewModel(api: api)
+        await viewModel.load()
+
+        let first = Task { await viewModel.setInList(itemID: 5, isInList: true) }
+        await fulfillment(of: [parked], timeout: 1.0)
+        let second = Task { await viewModel.setInList(itemID: 5, isInList: true) }
+
+        api.releaseAddItemToListCall(1)
+
+        let firstResult = await first.value
+        let secondResult = await second.value
+
+        XCTAssertTrue(firstResult)
+        XCTAssertFalse(secondResult)
+        XCTAssertEqual(api.addItemToListCallCount, 1)
+    }
+
+    func test_setInList_rejectedWhileDeleteInFlightForSameItem() async throws {
+        let item = try decodeItem(
+            """
+            {
+              "id": 9,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Cheese"
+            }
+            """
+        )
+
+        let api = MockItemsAPI(categories: [], items: [item])
+        api.blockedDeleteCallIndices = [1]
+
+        let parked = expectation(description: "delete call parked")
+        api.onDeleteCallParked = { callIndex in
+            if callIndex == 1 {
+                parked.fulfill()
+            }
+        }
+
+        let viewModel = ItemsViewModel(api: api)
+
+        let deleteTask = Task { await viewModel.deleteItem(id: 9) }
+        await fulfillment(of: [parked], timeout: 1.0)
+
+        let toggleResult = await viewModel.setInList(itemID: 9, isInList: true)
+        api.releaseDeleteCall(1)
+
+        XCTAssertFalse(toggleResult)
+        let deleteResult = await deleteTask.value
+
+        XCTAssertTrue(deleteResult)
+        XCTAssertEqual(api.deleteItemCallCount, 1)
+        XCTAssertEqual(api.addItemToListCallCount, 0)
+        XCTAssertEqual(api.removeItemFromListCallCount, 0)
     }
 
     func test_retryAndRefresh_refetchAndReplaceStaleCache() async throws {
@@ -492,6 +756,7 @@ private func decodeItem(_ json: String) throws -> Item {
 
 private final class NotificationRecorder: @unchecked Sendable {
     private let lock = NSLock()
+    private var notifications: [Notification] = []
     private var storedUserInfo: [AnyHashable: Any]?
     private var storedCount = 0
 
@@ -507,8 +772,15 @@ private final class NotificationRecorder: @unchecked Sendable {
         return storedCount
     }
 
+    var lastNotification: Notification? {
+        lock.lock()
+        defer { lock.unlock() }
+        return notifications.last
+    }
+
     func record(_ notification: Notification) {
         lock.lock()
+        notifications.append(notification)
         storedUserInfo = notification.userInfo
         storedCount += 1
         lock.unlock()
@@ -537,9 +809,25 @@ private final class MockItemsAPI: ItemsAPI {
     var createItemResult: Item?
     var updateItemResult: Item?
     var listItemsAfterSetInList: [Item]?
+    var listItemsResponsesByCall: [Int: [Item]] = [:]
 
-    var waitForCreate = false
-    private var createContinuation: CheckedContinuation<Void, Never>?
+    var blockedListItemsCallIndices: Set<Int> = []
+    var blockedCreateCallIndices: Set<Int> = []
+    var blockedUpdateCallIndices: Set<Int> = []
+    var blockedDeleteCallIndices: Set<Int> = []
+    var blockedAddItemToListCallIndices: Set<Int> = []
+
+    var onListItemsCallParked: ((Int) -> Void)?
+    var onCreateCallParked: ((Int) -> Void)?
+    var onUpdateCallParked: ((Int) -> Void)?
+    var onDeleteCallParked: ((Int) -> Void)?
+    var onAddItemToListCallParked: ((Int) -> Void)?
+
+    private var listItemsContinuations: [Int: CheckedContinuation<Void, Never>] = [:]
+    private var createContinuations: [Int: CheckedContinuation<Void, Never>] = [:]
+    private var updateContinuations: [Int: CheckedContinuation<Void, Never>] = [:]
+    private var deleteContinuations: [Int: CheckedContinuation<Void, Never>] = [:]
+    private var addItemToListContinuations: [Int: CheckedContinuation<Void, Never>] = [:]
 
     private(set) var createItemCallCount = 0
     private(set) var updateItemCallCount = 0
@@ -566,26 +854,45 @@ private final class MockItemsAPI: ItemsAPI {
 
     func listItems(inList: Bool?) async throws -> [Item] {
         listItemsCallCount += 1
+        let callIndex = listItemsCallCount
+
         if let listItemsError {
             throw listItemsError
         }
 
-        if let listItemsAfterSetInList {
-            return listItemsAfterSetInList
+        let response: [Item]
+        if let callSpecificResponse = listItemsResponsesByCall[callIndex] {
+            response = callSpecificResponse
+        } else if let listItemsAfterSetInList {
+            response = listItemsAfterSetInList
+        } else if let inList {
+            response = items.filter { ($0.list != nil) == inList }
+        } else {
+            response = items
         }
 
-        if let inList {
-            return items.filter { ($0.list != nil) == inList }
+        if blockedListItemsCallIndices.contains(callIndex) {
+            await withCheckedContinuation { continuation in
+                listItemsContinuations[callIndex] = continuation
+                onListItemsCallParked?(callIndex)
+            }
         }
-        return items
+
+        return response
+    }
+
+    func releaseListItemsCall(_ callIndex: Int) {
+        listItemsContinuations.removeValue(forKey: callIndex)?.resume()
     }
 
     func createItem(categoryID: Int, name: String) async throws -> Item {
         createItemCallCount += 1
+        let callIndex = createItemCallCount
 
-        if waitForCreate {
+        if blockedCreateCallIndices.contains(callIndex) {
             await withCheckedContinuation { continuation in
-                createContinuation = continuation
+                createContinuations[callIndex] = continuation
+                onCreateCallParked?(callIndex)
             }
         }
 
@@ -600,6 +907,14 @@ private final class MockItemsAPI: ItemsAPI {
 
     func updateItem(id: Int, categoryID: Int, name: String) async throws -> Item {
         updateItemCallCount += 1
+        let callIndex = updateItemCallCount
+
+        if blockedUpdateCallIndices.contains(callIndex) {
+            await withCheckedContinuation { continuation in
+                updateContinuations[callIndex] = continuation
+                onUpdateCallParked?(callIndex)
+            }
+        }
 
         if let updateItemError {
             throw updateItemError
@@ -614,6 +929,15 @@ private final class MockItemsAPI: ItemsAPI {
 
     func deleteItem(id: Int) async throws {
         deleteItemCallCount += 1
+        let callIndex = deleteItemCallCount
+
+        if blockedDeleteCallIndices.contains(callIndex) {
+            await withCheckedContinuation { continuation in
+                deleteContinuations[callIndex] = continuation
+                onDeleteCallParked?(callIndex)
+            }
+        }
+
         if let deleteItemError {
             throw deleteItemError
         }
@@ -622,6 +946,15 @@ private final class MockItemsAPI: ItemsAPI {
 
     func addItemToList(itemID: Int) async throws -> Item {
         addItemToListCallCount += 1
+        let callIndex = addItemToListCallCount
+
+        if blockedAddItemToListCallIndices.contains(callIndex) {
+            await withCheckedContinuation { continuation in
+                addItemToListContinuations[callIndex] = continuation
+                onAddItemToListCallParked?(callIndex)
+            }
+        }
+
         if let addItemToListError {
             throw addItemToListError
         }
@@ -647,8 +980,19 @@ private final class MockItemsAPI: ItemsAPI {
         }
     }
 
-    func releaseCreateContinuation() {
-        createContinuation?.resume()
-        createContinuation = nil
+    func releaseCreateCall(_ callIndex: Int) {
+        createContinuations.removeValue(forKey: callIndex)?.resume()
+    }
+
+    func releaseUpdateCall(_ callIndex: Int) {
+        updateContinuations.removeValue(forKey: callIndex)?.resume()
+    }
+
+    func releaseDeleteCall(_ callIndex: Int) {
+        deleteContinuations.removeValue(forKey: callIndex)?.resume()
+    }
+
+    func releaseAddItemToListCall(_ callIndex: Int) {
+        addItemToListContinuations.removeValue(forKey: callIndex)?.resume()
     }
 }

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
@@ -130,7 +130,7 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertFalse(updateResult)
         XCTAssertEqual(api.createItemCallCount, 0)
         XCTAssertEqual(api.updateItemCallCount, 0)
-        XCTAssertEqual(viewModel.errorMessage, "Item name is required.")
+        XCTAssertEqual(viewModel.mutationErrorMessage, "Item name is required.")
     }
 
     func test_addAndUpdate_requireCategory() async throws {
@@ -159,7 +159,7 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertFalse(updateResult)
         XCTAssertEqual(api.createItemCallCount, 0)
         XCTAssertEqual(api.updateItemCallCount, 0)
-        XCTAssertEqual(viewModel.errorMessage, "Category is required.")
+        XCTAssertEqual(viewModel.mutationErrorMessage, "Category is required.")
     }
 
     func test_loadFailure_keepsEmptySafeState_andRetryPathRecovers() async throws {
@@ -176,7 +176,7 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.items.isEmpty)
         XCTAssertTrue(viewModel.filteredItems.isEmpty)
         XCTAssertTrue(viewModel.categories.isEmpty)
-        XCTAssertNotNil(viewModel.errorMessage)
+        XCTAssertNotNil(viewModel.loadErrorMessage)
 
         api.listCategoriesError = nil
         api.listItemsError = nil
@@ -210,7 +210,7 @@ final class ItemsViewModelTests: XCTestCase {
 
         XCTAssertEqual(viewModel.items.map(\.name), ["Milk"])
         XCTAssertEqual(viewModel.categories.map(\.name), ["Dairy"])
-        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertNil(viewModel.loadErrorMessage)
         XCTAssertEqual(api.listCategoriesCallCount, 2)
         XCTAssertEqual(api.listItemsCallCount, 2)
     }
@@ -910,7 +910,7 @@ final class ItemsViewModelTests: XCTestCase {
 
         XCTAssertFalse(deleteResult)
         XCTAssertEqual(viewModel.items.map(\.id), [21])
-        XCTAssertEqual(viewModel.errorMessage, "Item is still referenced")
+        XCTAssertEqual(viewModel.mutationErrorMessage, "Item is still referenced")
     }
 
     func test_updateItem_notFound_keepsPriorState() async throws {
@@ -934,7 +934,7 @@ final class ItemsViewModelTests: XCTestCase {
 
         XCTAssertFalse(updateResult)
         XCTAssertEqual(viewModel.items.map(\.name), ["Milk"])
-        XCTAssertEqual(viewModel.errorMessage, "Item no longer exists")
+        XCTAssertEqual(viewModel.mutationErrorMessage, "Item no longer exists")
     }
 
     func test_deleteItem_notFound_keepsPriorState() async throws {
@@ -958,7 +958,7 @@ final class ItemsViewModelTests: XCTestCase {
 
         XCTAssertFalse(deleteResult)
         XCTAssertEqual(viewModel.items.map(\.name), ["Milk"])
-        XCTAssertEqual(viewModel.errorMessage, "Item no longer exists")
+        XCTAssertEqual(viewModel.mutationErrorMessage, "Item no longer exists")
     }
 
     func test_retryAndRefresh_refetchAndReplaceStaleCache() async throws {
@@ -1139,7 +1139,7 @@ final class ItemsViewModelTests: XCTestCase {
 
         XCTAssertFalse(result)
         XCTAssertEqual(viewModel.items.map(\.id), [1])
-        XCTAssertEqual(viewModel.errorMessage, "Item no longer exists")
+        XCTAssertEqual(viewModel.mutationErrorMessage, "Item no longer exists")
         XCTAssertEqual(recorder.count, 0)
     }
 }

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
@@ -1457,7 +1457,7 @@ private final class MockItemsAPI: ItemsAPI {
         items.removeAll(where: { $0.id == id })
     }
 
-    func addItemToList(itemID: Int) async throws -> Item {
+    func addItemToList(itemID: Int) async throws {
         addItemToListCallCount += 1
         let callIndex = addItemToListCallCount
 
@@ -1472,14 +1472,13 @@ private final class MockItemsAPI: ItemsAPI {
             throw addItemToListError
         }
 
-        if let listItemsAfterSetInList,
-            let item = listItemsAfterSetInList.first(where: { $0.id == itemID })
-        {
+        if let listItemsAfterSetInList {
             items = listItemsAfterSetInList
-            return item
         }
 
-        return try XCTUnwrap(items.first(where: { $0.id == itemID }))
+        guard items.contains(where: { $0.id == itemID }) else {
+            throw APIError.notFound("Item not found")
+        }
     }
 
     func removeItemFromList(itemID: Int) async throws {

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
@@ -401,6 +401,98 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertNotNil(userInfo[AppEvents.MembershipChanged.changedAtKey] as? Date)
     }
 
+    func test_setInListToggleOffSuccess_callsRemoveRefreshesAndPostsFalseNotification() async throws {
+        let notificationCenter = NotificationCenter()
+        let original = try decodeItem(
+            """
+            {
+              "id": 1,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk",
+              "list": { "id": 22, "quantity": "1", "done": false }
+            }
+            """
+        )
+        let toggledOff = try decodeItem(
+            """
+            {
+              "id": 1,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+        let api = MockItemsAPI(categories: [], items: [original])
+        api.listItemsAfterSetInList = [toggledOff]
+
+        let viewModel = ItemsViewModel(api: api, notificationCenter: notificationCenter)
+        await viewModel.load()
+
+        let recorder = NotificationRecorder()
+        let token = notificationCenter.addObserver(
+            forName: AppEvents.MembershipChanged.name,
+            object: nil,
+            queue: nil
+        ) { note in
+            recorder.record(note)
+        }
+        defer { notificationCenter.removeObserver(token) }
+
+        let ok = await viewModel.setInList(itemID: 1, isInList: false)
+
+        XCTAssertTrue(ok)
+        XCTAssertEqual(api.addItemToListCallCount, 0)
+        XCTAssertEqual(api.removeItemFromListCallCount, 1)
+        XCTAssertEqual(api.listItemsCallCount, 2)
+        XCTAssertNil(viewModel.items.first?.list)
+
+        let notification = try XCTUnwrap(recorder.lastNotification)
+        let userInfo = try XCTUnwrap(notification.userInfo)
+        XCTAssertEqual(userInfo[AppEvents.MembershipChanged.itemIDKey] as? Int, 1)
+        XCTAssertEqual(userInfo[AppEvents.MembershipChanged.isInListKey] as? Bool, false)
+    }
+
+    func test_setInListToggleOffFailure_preservesStateAndDoesNotPostNotification() async throws {
+        let notificationCenter = NotificationCenter()
+        let original = try decodeItem(
+            """
+            {
+              "id": 1,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk",
+              "list": { "id": 22, "quantity": "1", "done": false }
+            }
+            """
+        )
+        let api = MockItemsAPI(categories: [], items: [original])
+        api.removeItemFromListError = APIError.serverError("toggle off fail")
+
+        let viewModel = ItemsViewModel(api: api, notificationCenter: notificationCenter)
+        await viewModel.load()
+
+        let recorder = NotificationRecorder()
+        let token = notificationCenter.addObserver(
+            forName: AppEvents.MembershipChanged.name,
+            object: nil,
+            queue: nil
+        ) { note in
+            recorder.record(note)
+        }
+        defer { notificationCenter.removeObserver(token) }
+
+        let result = await viewModel.setInList(itemID: 1, isInList: false)
+
+        XCTAssertFalse(result)
+        XCTAssertEqual(api.addItemToListCallCount, 0)
+        XCTAssertEqual(api.removeItemFromListCallCount, 1)
+        XCTAssertEqual(api.listItemsCallCount, 1)
+        XCTAssertNotNil(viewModel.items.first?.list)
+        XCTAssertEqual(recorder.count, 0)
+    }
+
     func test_toggleAndDeleteFailure_preserveState_andToggleFailureDoesNotPostNotification() async throws {
         let notificationCenter = NotificationCenter()
         let original = try decodeItem(
@@ -651,6 +743,224 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertEqual(api.removeItemFromListCallCount, 0)
     }
 
+    func test_updateItem_rejectedWhileDeleteInFlightForSameItem() async throws {
+        let item = try decodeItem(
+            """
+            {
+              "id": 19,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Cheese"
+            }
+            """
+        )
+
+        let api = MockItemsAPI(categories: [], items: [item])
+        api.blockedDeleteCallIndices = [1]
+
+        let parked = expectation(description: "delete call parked")
+        api.onDeleteCallParked = { callIndex in
+            if callIndex == 1 {
+                parked.fulfill()
+            }
+        }
+
+        let viewModel = ItemsViewModel(api: api)
+
+        let deleteTask = Task { await viewModel.deleteItem(id: 19) }
+        await fulfillment(of: [parked], timeout: 1.0)
+
+        let saveResult = await viewModel.updateItem(id: 19, name: "Sharp Cheese", categoryID: 1)
+        api.releaseDeleteCall(1)
+
+        XCTAssertFalse(saveResult)
+        let deleteResult = await deleteTask.value
+
+        XCTAssertTrue(deleteResult)
+        XCTAssertEqual(api.deleteItemCallCount, 1)
+        XCTAssertEqual(api.updateItemCallCount, 0)
+    }
+
+    func test_editorMutations_lockEachOtherWhileUpdateInFlight() async throws {
+        let existingItem = try decodeItem(
+            """
+            {
+              "id": 14,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+        let updatedItem = try decodeItem(
+            """
+            {
+              "id": 14,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Oat Milk"
+            }
+            """
+        )
+
+        let api = MockItemsAPI(categories: [], items: [existingItem])
+        api.updateItemResult = updatedItem
+        api.blockedUpdateCallIndices = [1]
+
+        let parked = expectation(description: "update call parked")
+        api.onUpdateCallParked = { callIndex in
+            if callIndex == 1 {
+                parked.fulfill()
+            }
+        }
+
+        let viewModel = ItemsViewModel(api: api)
+
+        let saveTask = Task {
+            await viewModel.updateItem(id: 14, name: "Oat Milk", categoryID: 1)
+        }
+        await fulfillment(of: [parked], timeout: 1.0)
+
+        let toggleResult = await viewModel.setInList(itemID: 14, isInList: true)
+        let deleteResult = await viewModel.deleteItem(id: 14)
+
+        api.releaseUpdateCall(1)
+        let saveResult = await saveTask.value
+
+        XCTAssertTrue(saveResult)
+        XCTAssertFalse(toggleResult)
+        XCTAssertFalse(deleteResult)
+        XCTAssertEqual(api.updateItemCallCount, 1)
+        XCTAssertEqual(api.addItemToListCallCount, 0)
+        XCTAssertEqual(api.deleteItemCallCount, 0)
+    }
+
+    func test_editorMutations_lockEachOtherWhileToggleInFlight() async throws {
+        let item = try decodeItem(
+            """
+            {
+              "id": 15,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Cream"
+            }
+            """
+        )
+        let inListItem = try decodeItem(
+            """
+            {
+              "id": 15,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Cream",
+              "list": { "id": 40, "quantity": "1", "done": false }
+            }
+            """
+        )
+
+        let api = MockItemsAPI(categories: [], items: [item])
+        api.listItemsAfterSetInList = [inListItem]
+        api.blockedAddItemToListCallIndices = [1]
+
+        let parked = expectation(description: "toggle call parked")
+        api.onAddItemToListCallParked = { callIndex in
+            if callIndex == 1 {
+                parked.fulfill()
+            }
+        }
+
+        let viewModel = ItemsViewModel(api: api)
+        await viewModel.load()
+
+        let toggleTask = Task { await viewModel.setInList(itemID: 15, isInList: true) }
+        await fulfillment(of: [parked], timeout: 1.0)
+
+        let saveResult = await viewModel.updateItem(id: 15, name: "Whipping Cream", categoryID: 1)
+        let deleteResult = await viewModel.deleteItem(id: 15)
+
+        api.releaseAddItemToListCall(1)
+        let toggleResult = await toggleTask.value
+
+        XCTAssertTrue(toggleResult)
+        XCTAssertFalse(saveResult)
+        XCTAssertFalse(deleteResult)
+        XCTAssertEqual(api.addItemToListCallCount, 1)
+        XCTAssertEqual(api.updateItemCallCount, 0)
+        XCTAssertEqual(api.deleteItemCallCount, 0)
+    }
+
+    func test_deleteItem_conflict_keepsItemAndShowsError() async throws {
+        let item = try decodeItem(
+            """
+            {
+              "id": 21,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+
+        let api = MockItemsAPI(categories: [], items: [item])
+        api.deleteItemError = APIError.conflict("Item is still referenced")
+        let viewModel = ItemsViewModel(api: api)
+        await viewModel.load()
+
+        let deleteResult = await viewModel.deleteItem(id: 21)
+
+        XCTAssertFalse(deleteResult)
+        XCTAssertEqual(viewModel.items.map(\.id), [21])
+        XCTAssertEqual(viewModel.errorMessage, "Item is still referenced")
+    }
+
+    func test_updateItem_notFound_keepsPriorState() async throws {
+        let original = try decodeItem(
+            """
+            {
+              "id": 33,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+
+        let api = MockItemsAPI(categories: [], items: [original])
+        api.updateItemError = APIError.notFound("Item no longer exists")
+        let viewModel = ItemsViewModel(api: api)
+        await viewModel.load()
+
+        let updateResult = await viewModel.updateItem(id: 33, name: "Oat Milk", categoryID: 1)
+
+        XCTAssertFalse(updateResult)
+        XCTAssertEqual(viewModel.items.map(\.name), ["Milk"])
+        XCTAssertEqual(viewModel.errorMessage, "Item no longer exists")
+    }
+
+    func test_deleteItem_notFound_keepsPriorState() async throws {
+        let original = try decodeItem(
+            """
+            {
+              "id": 34,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+
+        let api = MockItemsAPI(categories: [], items: [original])
+        api.deleteItemError = APIError.notFound("Item no longer exists")
+        let viewModel = ItemsViewModel(api: api)
+        await viewModel.load()
+
+        let deleteResult = await viewModel.deleteItem(id: 34)
+
+        XCTAssertFalse(deleteResult)
+        XCTAssertEqual(viewModel.items.map(\.name), ["Milk"])
+        XCTAssertEqual(viewModel.errorMessage, "Item no longer exists")
+    }
+
     func test_retryAndRefresh_refetchAndReplaceStaleCache() async throws {
         let api = MockItemsAPI(
             categories: [
@@ -775,6 +1085,62 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isAddButtonDisabled(name: "   ", categoryID: 1))
         XCTAssertTrue(viewModel.isAddButtonDisabled(name: "Milk", categoryID: nil))
         XCTAssertFalse(viewModel.isAddButtonDisabled(name: " Milk ", categoryID: 1))
+    }
+
+    func test_itemEditorControlsDisabled_whileMutationInFlight() {
+        XCTAssertTrue(ItemEditorViewUX.cancelDisabled(isMutationInFlight: true))
+        XCTAssertTrue(ItemEditorViewUX.saveDisabled(isMutationInFlight: true, baseSaveDisabled: false))
+        XCTAssertTrue(ItemEditorViewUX.nameDisabled(isMutationInFlight: true))
+        XCTAssertTrue(ItemEditorViewUX.categoryDisabled(isMutationInFlight: true))
+        XCTAssertTrue(ItemEditorViewUX.membershipToggleDisabled(isMutationInFlight: true))
+        XCTAssertTrue(ItemEditorViewUX.deleteDisabled(isMutationInFlight: true))
+    }
+
+    func test_itemEditorAccessibilityLabels_remainStable() {
+        XCTAssertEqual(ItemEditorViewAccessibility.categoryLabel, "Edit item category")
+        XCTAssertEqual(ItemEditorViewAccessibility.nameLabel, "Edit item name")
+        XCTAssertEqual(ItemEditorViewAccessibility.membershipToggleLabel, "Include item in shopping list")
+        XCTAssertEqual(ItemEditorViewAccessibility.cancelButtonLabel, "Cancel edit item")
+        XCTAssertEqual(ItemEditorViewAccessibility.saveButtonLabel, "Save item changes")
+        XCTAssertEqual(ItemEditorViewAccessibility.deleteButtonLabel, "Delete item")
+        XCTAssertEqual(ItemEditorViewAccessibility.deleteConfirmButtonLabel, "Confirm delete item")
+        XCTAssertEqual(ItemEditorViewAccessibility.errorLabel, "Edit item error")
+    }
+
+    func test_setInList_notFound_keepsPriorState_andSurfacesError() async throws {
+        let notificationCenter = NotificationCenter()
+        let original = try decodeItem(
+            """
+            {
+              "id": 1,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+        let api = MockItemsAPI(categories: [], items: [original])
+        api.addItemToListError = APIError.notFound("Item no longer exists")
+
+        let viewModel = ItemsViewModel(api: api, notificationCenter: notificationCenter)
+        await viewModel.load()
+
+        let recorder = NotificationRecorder()
+        let token = notificationCenter.addObserver(
+            forName: AppEvents.MembershipChanged.name,
+            object: nil,
+            queue: nil
+        ) { note in
+            recorder.record(note)
+        }
+        defer { notificationCenter.removeObserver(token) }
+
+        let result = await viewModel.setInList(itemID: 1, isInList: true)
+
+        XCTAssertFalse(result)
+        XCTAssertEqual(viewModel.items.map(\.id), [1])
+        XCTAssertEqual(viewModel.errorMessage, "Item no longer exists")
+        XCTAssertEqual(recorder.count, 0)
     }
 }
 

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
@@ -1,0 +1,654 @@
+import GroceriesAPI
+import XCTest
+
+@testable import Aisle4
+
+@MainActor
+final class ItemsViewModelTests: XCTestCase {
+    func test_filteredItems_matchesCaseInsensitiveSubstring() async throws {
+        let api = MockItemsAPI(
+            categories: try decodeCategories(
+                """
+                [
+                  {
+                    "id": 1,
+                    "store_id": 1,
+                    "name": "Dairy",
+                    "description": "",
+                    "item_count": 3
+                  }
+                ]
+                """
+            ),
+            items: try decodeItems(
+                """
+                [
+                  {
+                    "id": 1,
+                    "category_id": 1,
+                    "category_name": "Dairy",
+                    "name": "Almond Milk"
+                  },
+                  {
+                    "id": 2,
+                    "category_id": 1,
+                    "category_name": "Dairy",
+                    "name": "Whole Milk"
+                  },
+                  {
+                    "id": 3,
+                    "category_id": 1,
+                    "category_name": "Dairy",
+                    "name": "Bread"
+                  }
+                ]
+                """
+            )
+        )
+        let viewModel = ItemsViewModel(api: api)
+
+        await viewModel.load()
+        viewModel.searchText = "mIlK"
+
+        XCTAssertEqual(viewModel.filteredItems.map(\.name), ["Almond Milk", "Whole Milk"])
+    }
+
+    func test_filteredItems_composesInListOnlyAndSearch() async throws {
+        let api = MockItemsAPI(
+            categories: try decodeCategories(
+                """
+                [
+                  {
+                    "id": 1,
+                    "store_id": 1,
+                    "name": "Dairy",
+                    "description": "",
+                    "item_count": 3
+                  }
+                ]
+                """
+            ),
+            items: try decodeItems(
+                """
+                [
+                  {
+                    "id": 1,
+                    "category_id": 1,
+                    "category_name": "Dairy",
+                    "name": "Almond Milk",
+                    "list": { "id": 100, "quantity": "1", "done": false }
+                  },
+                  {
+                    "id": 2,
+                    "category_id": 1,
+                    "category_name": "Dairy",
+                    "name": "Coconut Milk"
+                  },
+                  {
+                    "id": 3,
+                    "category_id": 1,
+                    "category_name": "Dairy",
+                    "name": "Pasta",
+                    "list": { "id": 101, "quantity": "1", "done": false }
+                  }
+                ]
+                """
+            )
+        )
+        let viewModel = ItemsViewModel(api: api)
+
+        await viewModel.load()
+        viewModel.inListOnly = true
+        viewModel.searchText = "milk"
+
+        XCTAssertEqual(viewModel.filteredItems.map(\.name), ["Almond Milk"])
+    }
+
+    func test_addAndUpdate_rejectTrimmedEmptyName() async throws {
+        let api = MockItemsAPI(
+            categories: try decodeCategories(
+                """
+                [
+                  {
+                    "id": 1,
+                    "store_id": 1,
+                    "name": "Dairy",
+                    "description": "",
+                    "item_count": 0
+                  }
+                ]
+                """
+            ),
+            items: []
+        )
+        let viewModel = ItemsViewModel(api: api)
+
+        let addResult = await viewModel.addItem(name: "   ", categoryID: 1)
+        let updateResult = await viewModel.updateItem(id: 42, name: "\n\t", categoryID: 1)
+
+        XCTAssertFalse(addResult)
+        XCTAssertFalse(updateResult)
+        XCTAssertEqual(api.createItemCallCount, 0)
+        XCTAssertEqual(api.updateItemCallCount, 0)
+        XCTAssertEqual(viewModel.errorMessage, "Item name is required.")
+    }
+
+    func test_addAndUpdate_requireCategory() async throws {
+        let api = MockItemsAPI(
+            categories: try decodeCategories(
+                """
+                [
+                  {
+                    "id": 1,
+                    "store_id": 1,
+                    "name": "Dairy",
+                    "description": "",
+                    "item_count": 0
+                  }
+                ]
+                """
+            ),
+            items: []
+        )
+        let viewModel = ItemsViewModel(api: api)
+
+        let addResult = await viewModel.addItem(name: "Apples", categoryID: nil)
+        let updateResult = await viewModel.updateItem(id: 42, name: "Apples", categoryID: nil)
+
+        XCTAssertFalse(addResult)
+        XCTAssertFalse(updateResult)
+        XCTAssertEqual(api.createItemCallCount, 0)
+        XCTAssertEqual(api.updateItemCallCount, 0)
+        XCTAssertEqual(viewModel.errorMessage, "Category is required.")
+    }
+
+    func test_loadFailure_keepsEmptySafeState_andRetryPathRecovers() async throws {
+        let api = MockItemsAPI(
+            categories: [],
+            items: [],
+            listCategoriesError: APIError.serverError("boom"),
+            listItemsError: APIError.serverError("boom")
+        )
+        let viewModel = ItemsViewModel(api: api)
+
+        await viewModel.load()
+
+        XCTAssertTrue(viewModel.items.isEmpty)
+        XCTAssertTrue(viewModel.filteredItems.isEmpty)
+        XCTAssertTrue(viewModel.categories.isEmpty)
+        XCTAssertNotNil(viewModel.errorMessage)
+
+        api.listCategoriesError = nil
+        api.listItemsError = nil
+        api.categories = try decodeCategories(
+            """
+            [
+              {
+                "id": 1,
+                "store_id": 1,
+                "name": "Dairy",
+                "description": "",
+                "item_count": 0
+              }
+            ]
+            """
+        )
+        api.items = try decodeItems(
+            """
+            [
+              {
+                "id": 1,
+                "category_id": 1,
+                "category_name": "Dairy",
+                "name": "Milk"
+              }
+            ]
+            """
+        )
+
+        await viewModel.retryLoad()
+
+        XCTAssertEqual(viewModel.items.map(\.name), ["Milk"])
+        XCTAssertEqual(viewModel.categories.map(\.name), ["Dairy"])
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertEqual(api.listCategoriesCallCount, 2)
+        XCTAssertEqual(api.listItemsCallCount, 2)
+    }
+
+    func test_addUpdateDeleteSuccess_updateLocalCache() async throws {
+        let api = MockItemsAPI(
+            categories: try decodeCategories(
+                """
+                [
+                  {
+                    "id": 1,
+                    "store_id": 1,
+                    "name": "Dairy",
+                    "description": "",
+                    "item_count": 0
+                  }
+                ]
+                """
+            ),
+            items: []
+        )
+        api.createItemResult = try decodeItem(
+            """
+            {
+              "id": 10,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Oat Milk"
+            }
+            """
+        )
+        api.updateItemResult = try decodeItem(
+            """
+            {
+              "id": 10,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Oat Milk Unsweetened"
+            }
+            """
+        )
+
+        let viewModel = ItemsViewModel(api: api)
+
+        let addOK = await viewModel.addItem(name: "Oat Milk", categoryID: 1)
+        XCTAssertTrue(addOK)
+        XCTAssertEqual(viewModel.items.map(\.name), ["Oat Milk"])
+
+        let updateOK = await viewModel.updateItem(id: 10, name: "Oat Milk Unsweetened", categoryID: 1)
+        XCTAssertTrue(updateOK)
+        XCTAssertEqual(viewModel.items.map(\.name), ["Oat Milk Unsweetened"])
+
+        let deleteOK = await viewModel.deleteItem(id: 10)
+        XCTAssertTrue(deleteOK)
+        XCTAssertTrue(viewModel.items.isEmpty)
+    }
+
+    func test_setInListSuccess_postsMembershipNotificationPayloadTypes() async throws {
+        let notificationCenter = NotificationCenter()
+        let api = MockItemsAPI(
+            categories: [],
+            items: [
+                try decodeItem(
+                    """
+                    {
+                      "id": 1,
+                      "category_id": 1,
+                      "category_name": "Dairy",
+                      "name": "Milk"
+                    }
+                    """
+                )
+            ]
+        )
+        api.listItemsAfterSetInList = [
+            try decodeItem(
+                """
+                {
+                  "id": 1,
+                  "category_id": 1,
+                  "category_name": "Dairy",
+                  "name": "Milk",
+                  "list": { "id": 22, "quantity": "1", "done": false }
+                }
+                """
+            )
+        ]
+
+        let viewModel = ItemsViewModel(api: api, notificationCenter: notificationCenter)
+        await viewModel.load()
+
+        let recorder = NotificationRecorder()
+        let token = notificationCenter.addObserver(
+            forName: AppEvents.MembershipChanged.name,
+            object: nil,
+            queue: nil
+        ) { note in
+            recorder.record(note)
+        }
+        defer { notificationCenter.removeObserver(token) }
+
+        let ok = await viewModel.setInList(itemID: 1, isInList: true)
+
+        XCTAssertTrue(ok)
+        let userInfo = try XCTUnwrap(recorder.lastUserInfo)
+        XCTAssertTrue(userInfo[AppEvents.MembershipChanged.itemIDKey] is Int)
+        XCTAssertTrue(userInfo[AppEvents.MembershipChanged.isInListKey] is Bool)
+        XCTAssertTrue(userInfo[AppEvents.MembershipChanged.changedAtKey] is Date)
+    }
+
+    func test_toggleAndDeleteFailure_preserveState_andToggleFailureDoesNotPostNotification() async throws {
+        let notificationCenter = NotificationCenter()
+        let original = try decodeItem(
+            """
+            {
+              "id": 1,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+        let api = MockItemsAPI(categories: [], items: [original])
+        api.addItemToListError = APIError.serverError("toggle fail")
+        api.deleteItemError = APIError.serverError("delete fail")
+
+        let viewModel = ItemsViewModel(api: api, notificationCenter: notificationCenter)
+        await viewModel.load()
+
+        let recorder = NotificationRecorder()
+        let token = notificationCenter.addObserver(
+            forName: AppEvents.MembershipChanged.name,
+            object: nil,
+            queue: nil
+        ) { _ in
+            recorder.recordCount()
+        }
+        defer { notificationCenter.removeObserver(token) }
+
+        let toggleOK = await viewModel.setInList(itemID: 1, isInList: true)
+        let deleteOK = await viewModel.deleteItem(id: 1)
+
+        XCTAssertFalse(toggleOK)
+        XCTAssertFalse(deleteOK)
+        XCTAssertEqual(recorder.count, 0)
+        XCTAssertEqual(viewModel.items.map(\.id), [1])
+    }
+
+    func test_duplicateSubmitProtection_allowsSingleInFlightCallPerOperation() async throws {
+        let api = MockItemsAPI(categories: [], items: [])
+        api.createItemResult = try decodeItem(
+            """
+            {
+              "id": 1,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+        api.waitForCreate = true
+
+        let viewModel = ItemsViewModel(api: api)
+
+        let first = Task { await viewModel.addItem(name: "Milk", categoryID: 1) }
+        let second = Task { await viewModel.addItem(name: "Milk", categoryID: 1) }
+
+        await Task.yield()
+        api.releaseCreateContinuation()
+
+        _ = await first.value
+        _ = await second.value
+
+        XCTAssertEqual(api.createItemCallCount, 1)
+    }
+
+    func test_retryAndRefresh_refetchAndReplaceStaleCache() async throws {
+        let api = MockItemsAPI(
+            categories: [
+                try decodeCategory(
+                    """
+                    {
+                      "id": 1,
+                      "store_id": 1,
+                      "name": "Old",
+                      "description": "",
+                      "item_count": 0
+                    }
+                    """
+                )
+            ],
+            items: [
+                try decodeItem(
+                    """
+                    {
+                      "id": 1,
+                      "category_id": 1,
+                      "category_name": "Old",
+                      "name": "Old Item"
+                    }
+                    """
+                )
+            ]
+        )
+        let viewModel = ItemsViewModel(api: api)
+
+        await viewModel.load()
+        XCTAssertEqual(viewModel.items.map(\.name), ["Old Item"])
+
+        api.categories = [
+            try decodeCategory(
+                """
+                {
+                  "id": 2,
+                  "store_id": 1,
+                  "name": "New",
+                  "description": "",
+                  "item_count": 0
+                }
+                """
+            )
+        ]
+        api.items = [
+            try decodeItem(
+                """
+                {
+                  "id": 2,
+                  "category_id": 2,
+                  "category_name": "New",
+                  "name": "New Item"
+                }
+                """
+            )
+        ]
+
+        await viewModel.retryLoad()
+        XCTAssertEqual(viewModel.items.map(\.name), ["New Item"])
+        XCTAssertEqual(viewModel.categories.map(\.name), ["New"])
+
+        api.items = [
+            try decodeItem(
+                """
+                {
+                  "id": 3,
+                  "category_id": 2,
+                  "category_name": "New",
+                  "name": "Newest Item"
+                }
+                """
+            )
+        ]
+
+        await viewModel.refresh()
+        XCTAssertEqual(viewModel.items.map(\.name), ["Newest Item"])
+        XCTAssertEqual(api.listCategoriesCallCount, 3)
+        XCTAssertEqual(api.listItemsCallCount, 3)
+    }
+}
+
+private func decodeCategories(_ json: String) throws -> [GroceriesAPI.Category] {
+    let data = try XCTUnwrap(json.data(using: .utf8))
+    return try JSONDecoder().decode([GroceriesAPI.Category].self, from: data)
+}
+
+private func decodeItems(_ json: String) throws -> [Item] {
+    let data = try XCTUnwrap(json.data(using: .utf8))
+    return try JSONDecoder().decode([Item].self, from: data)
+}
+
+private func decodeCategory(_ json: String) throws -> GroceriesAPI.Category {
+    let data = try XCTUnwrap(json.data(using: .utf8))
+    return try JSONDecoder().decode(GroceriesAPI.Category.self, from: data)
+}
+
+private func decodeItem(_ json: String) throws -> Item {
+    let data = try XCTUnwrap(json.data(using: .utf8))
+    return try JSONDecoder().decode(Item.self, from: data)
+}
+
+private final class NotificationRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedUserInfo: [AnyHashable: Any]?
+    private var storedCount = 0
+
+    var lastUserInfo: [AnyHashable: Any]? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedUserInfo
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedCount
+    }
+
+    func record(_ notification: Notification) {
+        lock.lock()
+        storedUserInfo = notification.userInfo
+        storedCount += 1
+        lock.unlock()
+    }
+
+    func recordCount() {
+        lock.lock()
+        storedCount += 1
+        lock.unlock()
+    }
+}
+
+@MainActor
+private final class MockItemsAPI: ItemsAPI {
+    var categories: [GroceriesAPI.Category]
+    var items: [Item]
+
+    var listCategoriesError: Error?
+    var listItemsError: Error?
+    var createItemError: Error?
+    var updateItemError: Error?
+    var deleteItemError: Error?
+    var addItemToListError: Error?
+    var removeItemFromListError: Error?
+
+    var createItemResult: Item?
+    var updateItemResult: Item?
+    var listItemsAfterSetInList: [Item]?
+
+    var waitForCreate = false
+    private var createContinuation: CheckedContinuation<Void, Never>?
+
+    private(set) var createItemCallCount = 0
+    private(set) var updateItemCallCount = 0
+    private(set) var listCategoriesCallCount = 0
+    private(set) var listItemsCallCount = 0
+    private(set) var deleteItemCallCount = 0
+    private(set) var addItemToListCallCount = 0
+    private(set) var removeItemFromListCallCount = 0
+
+    init(categories: [GroceriesAPI.Category], items: [Item], listCategoriesError: Error? = nil, listItemsError: Error? = nil) {
+        self.categories = categories
+        self.items = items
+        self.listCategoriesError = listCategoriesError
+        self.listItemsError = listItemsError
+    }
+
+    func listCategories() async throws -> [GroceriesAPI.Category] {
+        listCategoriesCallCount += 1
+        if let listCategoriesError {
+            throw listCategoriesError
+        }
+        return categories
+    }
+
+    func listItems(inList: Bool?) async throws -> [Item] {
+        listItemsCallCount += 1
+        if let listItemsError {
+            throw listItemsError
+        }
+
+        if let listItemsAfterSetInList {
+            return listItemsAfterSetInList
+        }
+
+        if let inList {
+            return items.filter { ($0.list != nil) == inList }
+        }
+        return items
+    }
+
+    func createItem(categoryID: Int, name: String) async throws -> Item {
+        createItemCallCount += 1
+
+        if waitForCreate {
+            await withCheckedContinuation { continuation in
+                createContinuation = continuation
+            }
+        }
+
+        if let createItemError {
+            throw createItemError
+        }
+
+        let result = try XCTUnwrap(createItemResult)
+        items.append(result)
+        return result
+    }
+
+    func updateItem(id: Int, categoryID: Int, name: String) async throws -> Item {
+        updateItemCallCount += 1
+
+        if let updateItemError {
+            throw updateItemError
+        }
+
+        let result = try XCTUnwrap(updateItemResult)
+        if let index = items.firstIndex(where: { $0.id == id }) {
+            items[index] = result
+        }
+        return result
+    }
+
+    func deleteItem(id: Int) async throws {
+        deleteItemCallCount += 1
+        if let deleteItemError {
+            throw deleteItemError
+        }
+        items.removeAll(where: { $0.id == id })
+    }
+
+    func addItemToList(itemID: Int) async throws -> Item {
+        addItemToListCallCount += 1
+        if let addItemToListError {
+            throw addItemToListError
+        }
+
+        if let listItemsAfterSetInList,
+            let item = listItemsAfterSetInList.first(where: { $0.id == itemID })
+        {
+            items = listItemsAfterSetInList
+            return item
+        }
+
+        return try XCTUnwrap(items.first(where: { $0.id == itemID }))
+    }
+
+    func removeItemFromList(itemID: Int) async throws {
+        removeItemFromListCallCount += 1
+        if let removeItemFromListError {
+            throw removeItemFromListError
+        }
+
+        if let listItemsAfterSetInList {
+            items = listItemsAfterSetInList
+        }
+    }
+
+    func releaseCreateContinuation() {
+        createContinuation?.resume()
+        createContinuation = nil
+    }
+}

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
@@ -732,6 +732,50 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertEqual(api.listCategoriesCallCount, 3)
         XCTAssertEqual(api.listItemsCallCount, 3)
     }
+
+    func test_addFlowControlsDisabled_whileAddRequestInFlight() async throws {
+        let api = MockItemsAPI(categories: [], items: [])
+        api.createItemResult = try decodeItem(
+            """
+            {
+              "id": 44,
+              "category_id": 1,
+              "category_name": "Dairy",
+              "name": "Milk"
+            }
+            """
+        )
+        api.blockedCreateCallIndices = [1]
+
+        let parked = expectation(description: "create call parked")
+        api.onCreateCallParked = { callIndex in
+            if callIndex == 1 {
+                parked.fulfill()
+            }
+        }
+
+        let viewModel = ItemsViewModel(api: api)
+
+        let addTask = Task { await viewModel.addItem(name: "Milk", categoryID: 1) }
+        await fulfillment(of: [parked], timeout: 1.0)
+
+        XCTAssertTrue(viewModel.isAdding)
+        XCTAssertTrue(viewModel.isAddButtonDisabled(name: "Milk", categoryID: 1))
+        XCTAssertTrue(viewModel.isAddCategoryPickerDisabled)
+        XCTAssertTrue(viewModel.isAddNameFieldDisabled)
+
+        api.releaseCreateCall(1)
+        _ = await addTask.value
+    }
+
+    func test_addFlowValidation_requiresTrimmedNameAndCategory() async throws {
+        let api = MockItemsAPI(categories: [], items: [])
+        let viewModel = ItemsViewModel(api: api)
+
+        XCTAssertTrue(viewModel.isAddButtonDisabled(name: "   ", categoryID: 1))
+        XCTAssertTrue(viewModel.isAddButtonDisabled(name: "Milk", categoryID: nil))
+        XCTAssertFalse(viewModel.isAddButtonDisabled(name: " Milk ", categoryID: 1))
+    }
 }
 
 private func decodeCategories(_ json: String) throws -> [GroceriesAPI.Category] {

--- a/clients/ios/Tests/GroceriesTests/Features/Navigation/AppNavigationTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Navigation/AppNavigationTests.swift
@@ -3,8 +3,15 @@ import XCTest
 @testable import Aisle4
 
 final class AppNavigationTests: XCTestCase {
-    func test_appTabsIncludeListAndAccount() {
-        XCTAssertEqual(AppTab.allCases, [.list, .account])
+    func test_appTabsIncludeListItemsAndAccount() {
+        XCTAssertEqual(AppTab.allCases, [.list, .items, .account])
+    }
+
+    func test_itemsMembershipDidChangeNotificationPayloadKeys() {
+        XCTAssertEqual(AppEvents.MembershipChanged.name.rawValue, "itemsMembershipDidChange")
+        XCTAssertEqual(AppEvents.MembershipChanged.itemIDKey, "itemID")
+        XCTAssertEqual(AppEvents.MembershipChanged.isInListKey, "isInList")
+        XCTAssertEqual(AppEvents.MembershipChanged.changedAtKey, "changedAt")
     }
 
     func test_accountDisplayUsernameText_usesUserName() {

--- a/clients/ios/Tests/GroceriesTests/Features/ShoppingList/ShoppingListAutoRefreshCoordinatorTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/ShoppingList/ShoppingListAutoRefreshCoordinatorTests.swift
@@ -34,4 +34,116 @@ final class ShoppingListAutoRefreshCoordinatorTests: XCTestCase {
         XCTAssertEqual(action, .refreshNow)
         XCTAssertFalse(coordinator.pendingRefresh)
     }
+
+    func test_refreshRequestGate_notificationBurst_collapsesToOneRefreshRequest() {
+        var gate = ShoppingListRefreshRequestGate()
+        let now = Date()
+
+        let first = gate.shouldStartRefresh(trigger: .membershipChanged, now: now)
+        gate.refreshCompleted()
+        let second = gate.shouldStartRefresh(
+            trigger: .membershipChanged,
+            now: now.addingTimeInterval(0.1)
+        )
+        let third = gate.shouldStartRefresh(
+            trigger: .membershipChanged,
+            now: now.addingTimeInterval(0.2)
+        )
+
+        XCTAssertTrue(first)
+        XCTAssertFalse(second)
+        XCTAssertFalse(third)
+    }
+
+    func test_refreshRequestGate_notificationDuringInFlight_doesNotOverlapRefresh() {
+        var gate = ShoppingListRefreshRequestGate()
+        let now = Date()
+
+        let first = gate.shouldStartRefresh(trigger: .membershipChanged, now: now)
+        let second = gate.shouldStartRefresh(
+            trigger: .membershipChanged,
+            now: now.addingTimeInterval(0.4)
+        )
+
+        XCTAssertTrue(first)
+        XCTAssertFalse(second)
+    }
+
+    func test_refreshRequestGate_onAppearAndNotification_shareGateLogic() {
+        var gate = ShoppingListRefreshRequestGate()
+        let now = Date()
+
+        let onAppear = gate.shouldStartRefresh(trigger: .onAppear, now: now)
+        gate.refreshCompleted()
+        let notification = gate.shouldStartRefresh(
+            trigger: .membershipChanged,
+            now: now.addingTimeInterval(0.1)
+        )
+
+        XCTAssertTrue(onAppear)
+        XCTAssertFalse(notification)
+    }
+
+    func test_refreshRequestGate_notificationAndImmediateTabSwitchRace_triggersExactlyOneRefresh() {
+        var gate = ShoppingListRefreshRequestGate()
+        let now = Date()
+
+        let notification = gate.shouldStartRefresh(trigger: .membershipChanged, now: now)
+        let tabSwitchAppear = gate.shouldStartRefresh(
+            trigger: .onAppear,
+            now: now.addingTimeInterval(0.01)
+        )
+
+        XCTAssertTrue(notification)
+        XCTAssertFalse(tabSwitchAppear)
+    }
+
+    func test_membershipObserver_repeatedAppearDisappearCycles_doNotRegisterDuplicates() {
+        let center = NotificationCenter()
+        let probe = MembershipRefreshObserverProbe(notificationCenter: center)
+        let counter = CallbackCounter()
+
+        for _ in 0..<3 {
+            probe.start {
+                counter.increment()
+            }
+            center.post(name: AppEvents.MembershipChanged.name, object: nil)
+            probe.stop()
+        }
+
+        XCTAssertEqual(counter.value, 3)
+    }
+}
+
+private final class CallbackCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func increment() {
+        lock.lock()
+        storage += 1
+        lock.unlock()
+    }
+}
+
+private final class MembershipRefreshObserverProbe {
+    private let observer: ShoppingListMembershipRefreshObserver
+
+    init(notificationCenter: NotificationCenter) {
+        observer = ShoppingListMembershipRefreshObserver(notificationCenter: notificationCenter)
+    }
+
+    func start(onMembershipChanged: @escaping @Sendable () -> Void) {
+        observer.start(onMembershipChanged: onMembershipChanged)
+    }
+
+    func stop() {
+        observer.stop()
+    }
 }

--- a/docs/superpowers/plans/2026-03-25-ios-items-management.md
+++ b/docs/superpowers/plans/2026-03-25-ios-items-management.md
@@ -1,0 +1,481 @@
+# iOS Items Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated iOS Items tab (between List and Account) with add/edit/delete and edit-screen-only shopping-list membership toggling, including deterministic Shopping List consistency after membership changes.
+
+**Architecture:** Introduce an isolated `Features/Items` module with its own view model and editor/add views, keep `ShoppingListViewModel` independent, and synchronize membership changes via a shared `NotificationCenter` event plus a deduped refresh coordinator path in `ShoppingListView`. Add explicit GroceriesAPI item endpoints in a dedicated `ItemEndpoints.swift` file.
+
+**Tech Stack:** Swift 6, SwiftUI, Observation (`@Observable`), async/await, XCTest, Tuist, URLSession + `MockURLProtocol`.
+
+---
+
+## File Map
+
+### Create
+
+- `clients/ios/Sources/GroceriesAPI/ItemEndpoints.swift` — item list/create/update/delete endpoint wrappers.
+- `clients/ios/Sources/Groceries/Shared/AppEvents.swift` — notification names + payload keys for cross-feature sync.
+- `clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift` — item screen state, filtering, mutations.
+- `clients/ios/Sources/Groceries/Features/Items/ItemsView.swift` — item list/search/filter and navigation entry points.
+- `clients/ios/Sources/Groceries/Features/Items/AddItemView.swift` — required category + name item creation form.
+- `clients/ios/Sources/Groceries/Features/Items/ItemEditorView.swift` — edit name/category, toggle list membership, delete confirmation.
+- `clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift` — feature logic tests.
+
+### Modify
+
+- `clients/ios/Sources/GroceriesAPI/Models.swift` — add `CreateItemRequest` and `UpdateItemRequest`.
+- `clients/ios/Sources/Groceries/Features/Navigation/AppTabsView.swift` — insert `items` tab between `list` and `account`.
+- `clients/ios/Sources/Groceries/Features/ShoppingList/ShoppingListView.swift` — subscribe to membership event and refresh through deduped path.
+- `clients/ios/Tests/GroceriesAPITests/GroceriesAPIClientTests.swift` — endpoint/query/error-mapping coverage.
+- `clients/ios/Tests/GroceriesTests/Features/Navigation/AppNavigationTests.swift` — tab-order assertion update.
+- `clients/ios/Tests/GroceriesTests/Features/ShoppingList/ShoppingListAutoRefreshCoordinatorTests.swift` — dedupe/race refresh coverage.
+- `clients/ios/README.md` — update architecture + future-work sections for new Items feature.
+
+---
+
+### Task 1: Add API request models (TDD)
+
+**Files:**
+- Modify: `clients/ios/Tests/GroceriesAPITests/GroceriesAPIClientTests.swift`
+- Modify: `clients/ios/Sources/GroceriesAPI/Models.swift`
+
+- [ ] **Step 1: Write failing model-encoding tests**
+
+```swift
+func testEncodeCreateItemRequest() throws {
+    let body = CreateItemRequest(categoryID: 3, name: "Apples")
+    let data = try JSONEncoder.apiEncoder.encode(body)
+    let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+    XCTAssertTrue(json.contains("\"category_id\":3"))
+    XCTAssertTrue(json.contains("\"name\":\"Apples\""))
+}
+
+func testEncodeUpdateItemRequest() throws {
+    let body = UpdateItemRequest(categoryID: 9, name: "Oat Milk")
+    let data = try JSONEncoder.apiEncoder.encode(body)
+    let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+    XCTAssertTrue(json.contains("\"category_id\":9"))
+    XCTAssertTrue(json.contains("\"name\":\"Oat Milk\""))
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesAPI -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:GroceriesAPITests/GroceriesAPIClientTests/testEncodeCreateItemRequest -only-testing:GroceriesAPITests/GroceriesAPIClientTests/testEncodeUpdateItemRequest`
+Expected: FAIL due to missing request model types.
+
+- [ ] **Step 3: Implement minimal request models**
+
+```swift
+public struct CreateItemRequest: Encodable, Sendable {
+    public let categoryID: Int
+    public let name: String
+
+    enum CodingKeys: String, CodingKey {
+        case categoryID = "category_id"
+        case name
+    }
+}
+
+public struct UpdateItemRequest: Encodable, Sendable {
+    public let categoryID: Int
+    public let name: String
+
+    enum CodingKeys: String, CodingKey {
+        case categoryID = "category_id"
+        case name
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run the same command as Step 2.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/ios/Sources/GroceriesAPI/Models.swift clients/ios/Tests/GroceriesAPITests/GroceriesAPIClientTests.swift
+git commit -m "test: add item request model encoding coverage"
+```
+
+---
+
+### Task 2: Add item API endpoints and API tests (TDD)
+
+**Files:**
+- Create: `clients/ios/Sources/GroceriesAPI/ItemEndpoints.swift`
+- Modify: `clients/ios/Tests/GroceriesAPITests/GroceriesAPIClientTests.swift`
+
+- [ ] **Step 1: Write failing endpoint tests**
+
+Add tests for:
+- `testListItems_withInListQueryEncodesQueryItem`
+- `testCreateItem_postsExpectedBody`
+- `testUpdateItem_putsExpectedBody`
+- `testDeleteItem_sendsDelete`
+- `testDeleteItem_conflict_throws409`
+- `testUpdateItem_notFound_throws404`
+- `testDeleteItem_notFound_throws404`
+
+Use `MockURLProtocol.setRequestHandler` to assert method/path/query/body.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesAPI -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:GroceriesAPITests/GroceriesAPIClientTests`
+Expected: FAIL for missing methods in `GroceriesAPIClient` extension.
+
+- [ ] **Step 3: Implement minimal endpoint wrappers**
+
+```swift
+public func listItems(categoryID: Int? = nil, inList: Bool? = nil) async throws -> [Item]
+public func createItem(categoryID: Int, name: String) async throws -> Item
+public func updateItem(id: Int, categoryID: Int, name: String) async throws -> Item
+public func deleteItem(id: Int) async throws
+```
+
+Build query items only when parameters are non-nil.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run the same command as Step 2.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/ios/Sources/GroceriesAPI/ItemEndpoints.swift clients/ios/Tests/GroceriesAPITests/GroceriesAPIClientTests.swift
+git commit -m "feat: add iOS item management API endpoints"
+```
+
+---
+
+### Task 3: Add shared app event contract and navigation tab order (TDD)
+
+**Files:**
+- Create: `clients/ios/Sources/Groceries/Shared/AppEvents.swift`
+- Modify: `clients/ios/Sources/Groceries/Features/Navigation/AppTabsView.swift`
+- Modify: `clients/ios/Tests/GroceriesTests/Features/Navigation/AppNavigationTests.swift`
+
+- [ ] **Step 1: Write failing navigation and event-contract tests**
+
+Add/adjust tests:
+- `test_appTabsIncludeListItemsAndAccount`
+- `test_itemsMembershipDidChangeNotificationPayloadKeys`
+
+```swift
+XCTAssertEqual(AppTab.allCases, [.list, .items, .account])
+XCTAssertEqual(AppEvents.MembershipChanged.itemIDKey, "itemID")
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:GroceriesTests/AppNavigationTests`
+Expected: FAIL due to missing `items` tab/event constants.
+
+- [ ] **Step 3: Implement tab enum update and shared event constants**
+
+Create constants similar to:
+
+```swift
+enum AppEvents {
+    enum MembershipChanged {
+        static let name = Notification.Name("itemsMembershipDidChange")
+        static let itemIDKey = "itemID"
+        static let isInListKey = "isInList"
+        static let changedAtKey = "changedAt"
+    }
+}
+```
+
+Insert the Items tab between existing List and Account tabs.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run command from Step 2.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/ios/Sources/Groceries/Shared/AppEvents.swift clients/ios/Sources/Groceries/Features/Navigation/AppTabsView.swift clients/ios/Tests/GroceriesTests/Features/Navigation/AppNavigationTests.swift
+git commit -m "feat: add items tab and shared app event contract"
+```
+
+---
+
+### Task 4: Implement ItemsViewModel with filtering and mutation logic (TDD)
+
+**Files:**
+- Create: `clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift`
+- Create: `clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift`
+
+- [ ] **Step 1: Write failing ViewModel tests for search/filter and validation**
+
+Add tests for:
+- case-insensitive substring filtering
+- in-list-only + search composition
+- trimmed-empty name validation on add/edit
+- required category validation
+- initial load failure keeps empty-safe state and exposes retry path
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:GroceriesTests/ItemsViewModelTests`
+Expected: FAIL because `ItemsViewModel` and APIs are missing.
+
+- [ ] **Step 3: Implement minimal ItemsViewModel state + pure filtering**
+
+Implement:
+- `items`, `filteredItems`, `searchText`, `inListOnly`, `categories`, `errorMessage`, and in-flight flags.
+- `applyFilters()` and validation helpers.
+
+- [ ] **Step 4: Add failing tests for mutation semantics and event emission**
+
+Add tests for:
+- add/edit/delete success mutating local cache
+- toggle membership success emits notification with correct payload types
+- toggle/delete failure preserves visible state
+- failed toggle does not emit membership-change notification
+- duplicate-submit protection while in flight
+- manual retry re-fetches categories + items and clears stale cache
+- pull-to-refresh re-fetches categories + items and replaces stale cache
+
+- [ ] **Step 5: Run tests to verify RED**
+
+Run command from Step 2.
+Expected: FAIL for missing mutation implementations.
+
+- [ ] **Step 6: Implement minimal mutation behavior**
+
+Implement `addItem`, `updateItem`, `deleteItem`, `setInList` with:
+- pessimistic commit
+- in-flight gates
+- notification posting on membership success only
+
+- [ ] **Step 7: Run tests to verify GREEN**
+
+Run command from Step 2.
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
+git commit -m "feat: add items view model with filtering and mutations"
+```
+
+---
+
+### Task 5: Build Items list and Add view UI (TDD for behavior-driving helpers)
+
+**Files:**
+- Create: `clients/ios/Sources/Groceries/Features/Items/ItemsView.swift`
+- Create: `clients/ios/Sources/Groceries/Features/Items/AddItemView.swift`
+- Modify: `clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift`
+
+- [ ] **Step 1: Add failing tests for Add flow behavior exposed by ViewModel**
+
+Test behaviors:
+- add button disabled while add request in-flight
+- category picker disabled while add request in-flight
+- name field disabled while add request in-flight
+- add requires non-empty trimmed name and category
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:GroceriesTests/ItemsViewModelTests`
+Expected: FAIL for missing `isAdding`/validation gates.
+
+- [ ] **Step 3: Implement minimal behavior in ViewModel and wire UI**
+
+Build `ItemsView` with:
+- search field
+- `In List only` toggle
+- list of filtered items
+- add button opening `AddItemView`
+
+Build `AddItemView` with:
+- category picker (required)
+- name field (required)
+- save/cancel actions
+- category picker + name field disabled while add request is in-flight
+- required accessibility labels for key controls
+
+- [ ] **Step 4: Run targeted tests + compile checks**
+
+Run:
+- `xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:GroceriesTests/ItemsViewModelTests`
+- `xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesTests -destination 'platform=iOS Simulator,name=iPhone 17'`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/ios/Sources/Groceries/Features/Items/ItemsView.swift clients/ios/Sources/Groceries/Features/Items/AddItemView.swift clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
+git commit -m "feat: add items list screen and add-item flow"
+```
+
+---
+
+### Task 6: Build ItemEditor view with toggle/delete semantics (TDD)
+
+**Files:**
+- Create: `clients/ios/Sources/Groceries/Features/Items/ItemEditorView.swift`
+- Modify: `clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift`
+
+- [ ] **Step 1: Write failing tests for editor mutation matrix and failure semantics**
+
+Add tests for:
+- save/toggle/delete lock each other while in flight
+- delete 409 keeps editor state and shows error
+- 404 failure keeps prior state
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:GroceriesTests/ItemsViewModelTests`
+Expected: FAIL because state rules are not fully implemented.
+
+- [ ] **Step 3: Implement ItemEditorView + ViewModel gates**
+
+Implement editor UI with:
+- name and category editable fields
+- in-list toggle (editor only)
+- delete confirmation dialog
+- disable controls based on active mutation
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run command from Step 2.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/ios/Sources/Groceries/Features/Items/ItemEditorView.swift clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
+git commit -m "feat: add item editor with toggle and delete confirmation"
+```
+
+---
+
+### Task 7: Wire Shopping List refresh coordination and dedupe (TDD)
+
+**Files:**
+- Modify: `clients/ios/Sources/Groceries/Features/ShoppingList/ShoppingListView.swift`
+- Modify: `clients/ios/Tests/GroceriesTests/Features/ShoppingList/ShoppingListAutoRefreshCoordinatorTests.swift`
+
+- [ ] **Step 1: Write failing tests for deduped refresh behavior**
+
+Add tests for:
+- notification burst collapses to one refresh request
+- notification during in-flight refresh does not trigger overlapping refresh
+- on-appear trigger and notification trigger share same gate logic
+- notification + immediate tab switch race results in exactly one refresh
+- repeated appear/disappear cycles do not register duplicate notification observers
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:GroceriesTests/ShoppingListAutoRefreshCoordinatorTests`
+Expected: FAIL due to missing trigger-coordination behavior.
+
+- [ ] **Step 3: Implement minimal refresh coordinator integration**
+
+Update `ShoppingListView` to route both:
+- `onAppear` refresh request
+- `AppEvents.MembershipChanged.name` notification refresh request
+
+through one deduped refresh entry point that respects `isRefreshingList` and 300ms dedupe.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run command from Step 2.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/ios/Sources/Groceries/Features/ShoppingList/ShoppingListView.swift clients/ios/Tests/GroceriesTests/Features/ShoppingList/ShoppingListAutoRefreshCoordinatorTests.swift
+git commit -m "fix: refresh shopping list after item membership changes"
+```
+
+---
+
+### Task 8: Integrate app navigation and run full iOS test suite
+
+**Files:**
+- Modify: `clients/ios/README.md`
+
+- [ ] **Step 1: Verify Items tab integration from Task 3 is complete**
+
+Ensure `TabView` order is:
+1) List
+2) Items
+3) Account
+
+and `ItemsView(apiClient:)` receives the authenticated client.
+
+No additional functional edits to `AppTabsView.swift` should be needed in this task; this step is verification-only to avoid churn.
+
+- [ ] **Step 2: Run full API and app tests**
+
+Run:
+
+```bash
+xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesAPI -destination 'platform=iOS Simulator,name=iPhone 17'
+xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesTests -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+
+Expected: PASS for both schemes.
+
+- [ ] **Step 3: Run formatting/lint checks used by project workflow (if configured)**
+
+Run: `mise run lint` (repo root)
+Expected: PASS (or document any unrelated pre-existing failures).
+
+- [ ] **Step 4: Update iOS README feature notes**
+
+Document new Items feature in architecture/future-work sections so docs match shipped behavior.
+
+- [ ] **Step 5: Run manual simulator verification checklist**
+
+In simulator, verify:
+1) Add item requires category and name.
+2) Edit name/category saves correctly.
+3) Toggle in-list in editor reflects in Shopping List after returning.
+4) Delete requires confirmation and removes item.
+5) Force failure paths (e.g., API unavailable/4xx) preserve previous visible state and show error.
+6) Failed membership toggle does not trigger cross-tab refresh side effects.
+7) Add and Edit controls include clear accessibility labels and disable correctly during in-flight mutations.
+8) Delete action is explicitly destructive and requires confirmation before execution.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clients/ios/README.md
+git commit -m "feat: integrate items management tab into iOS app"
+```
+
+---
+
+## Final Verification Checklist
+
+- [ ] `GroceriesAPI` tests pass locally.
+- [ ] `GroceriesTests` pass locally.
+- [ ] Tab order is exactly List, Items, Account.
+- [ ] Add/Edit require category and non-empty name.
+- [ ] In-list toggle exists only in editor and is pessimistic.
+- [ ] Delete uses confirmation dialog and handles conflict errors.
+- [ ] Membership toggle updates Shopping List view via event + deduped refresh path.
+- [ ] README reflects new feature structure.
+
+---
+
+## Notes for Execution
+
+- Follow @superpowers/test-driven-development on each task.
+- Keep commits small and task-scoped.
+- Prefer minimal implementation per test; avoid speculative abstractions.
+- If API contracts differ from OpenAPI during implementation, update tests first, then adjust endpoint code.

--- a/docs/superpowers/specs/2026-03-25-ios-items-management-design.md
+++ b/docs/superpowers/specs/2026-03-25-ios-items-management-design.md
@@ -1,0 +1,313 @@
+# iOS Items Management — Design Spec
+
+**Date:** 2026-03-25
+**Status:** Approved
+
+---
+
+## 1. Scope & Goals
+
+This feature adds a dedicated Items section to the iOS client for item-catalog management, matching the existing webapp capability pattern while preserving iOS-specific flow and usability.
+
+### In scope
+
+- Add a new item with required category selection.
+- View and search/filter a long list of items.
+- Open a dedicated edit screen per item.
+- Update item name and category.
+- Toggle whether an item is in the shopping list (edit screen only).
+- Delete an item with destructive confirmation.
+- Place the Items tab between List and Account in bottom navigation.
+- Ensure Shopping List reflects in/out-of-list changes made from Items.
+
+### Out of scope
+
+- Bulk-edit operations from the item list screen.
+- Editing item quantity from the Items feature.
+- Replacing existing Shopping List architecture with a fully shared global store.
+- SSE-based live synchronization for the Items feature.
+
+---
+
+## 2. Architecture & Navigation
+
+The feature is implemented as a dedicated module under `Features/Items` with its own view model and navigation stack.
+
+- Add a new `items` tab in `AppTabsView` between `list` and `account`.
+- `ItemsView` owns browse/search/filter experience.
+- Tapping an item pushes `ItemEditorView` so edit controls have full-screen space.
+- Add action opens `AddItemView` to create a new catalog item.
+- `ShoppingListView` remains independent and refreshes when item list-membership changes are published.
+
+This keeps item-management concerns isolated from shopping-list concerns while still providing deterministic cross-tab consistency.
+
+---
+
+## 3. File Structure
+
+### New files
+
+- `clients/ios/Sources/Groceries/Features/Items/ItemsView.swift`
+- `clients/ios/Sources/Groceries/Features/Items/ItemsViewModel.swift`
+- `clients/ios/Sources/Groceries/Features/Items/AddItemView.swift`
+- `clients/ios/Sources/Groceries/Features/Items/ItemEditorView.swift`
+
+### Modified files
+
+- `clients/ios/Sources/Groceries/Features/Navigation/AppTabsView.swift`
+  - Add `AppTab.items` and place its tab item between List and Account.
+- `clients/ios/Sources/Groceries/Features/ShoppingList/ShoppingListView.swift`
+  - Listen for item-membership-change event and refresh.
+  - Refresh on re-appear safety path.
+- `clients/ios/Sources/Groceries/Shared/AppEvents.swift` (new shared constants file)
+  - Define `Notification.Name` constants and payload keys used for cross-feature sync.
+- `clients/ios/Sources/GroceriesAPI/Models.swift`
+  - Add `CreateItemRequest` and `UpdateItemRequest` request models.
+- `clients/ios/Sources/GroceriesAPI/ItemEndpoints.swift` (new)
+  - Add item-management endpoint wrappers for list/create/update/delete.
+
+### Test files added/updated
+
+- `clients/ios/Tests/GroceriesAPITests/GroceriesAPIClientTests.swift`
+- `clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift` (new)
+- `clients/ios/Tests/GroceriesTests/Features/Navigation/AppNavigationTests.swift`
+
+---
+
+## 4. Data & Endpoint Contract
+
+The iOS client uses existing backend item and list endpoints from `openapi.yaml`.
+
+### Item catalog endpoints
+
+- `GET /api/v1/items`
+- `POST /api/v1/items`
+- `PUT /api/v1/items/{id}`
+- `DELETE /api/v1/items/{id}`
+
+### Concrete iOS client API contract
+
+`ItemEndpoints.swift` will define the exact public methods below:
+
+```swift
+public func listItems(categoryID: Int? = nil, inList: Bool? = nil) async throws -> [Item]
+public func createItem(categoryID: Int, name: String) async throws -> Item
+public func updateItem(id: Int, categoryID: Int, name: String) async throws -> Item
+public func deleteItem(id: Int) async throws
+```
+
+### Filtering strategy (v1)
+
+- V1 uses **client-side filtering only** for predictable UX and low latency while typing.
+- `ItemsViewModel` fetches the full item catalog once on screen load and filters in memory.
+- Text search and `In List only` toggle are composed in memory.
+- Query-param-based server filtering (`category_id`, `in_list`) remains available in API but is not used in v1 UI flow.
+
+### Cache freshness policy
+
+- Initial load: fetch categories + items in parallel.
+- Manual retry path: re-fetch categories + items.
+- Pull-to-refresh in `ItemsView`: re-fetch categories + items.
+- App foreground: no automatic fetch in v1 (avoid surprise network churn).
+- Mutation success updates local cache immediately (add/edit/delete/toggle).
+- Mutation failure does not mutate cache; error is shown and user may retry.
+
+### Shopping-list membership endpoints
+
+- Add to list: `POST /api/v1/list/items` with `item_id`.
+- Remove from list: `DELETE /api/v1/list/items/{itemID}`.
+
+### iOS request models
+
+```swift
+public struct CreateItemRequest: Encodable, Sendable {
+    public let categoryID: Int
+    public let name: String
+}
+
+public struct UpdateItemRequest: Encodable, Sendable {
+    public let categoryID: Int
+    public let name: String
+}
+```
+
+---
+
+## 5. Interaction Flow
+
+### 5.1 Items list screen
+
+- On first appear, load categories and items.
+- Show search field and `In List only` toggle.
+- Default list mode: all items.
+- Search is client-side, case-insensitive substring against item name.
+- `In List only` filter composes with text search.
+- Filtering is applied in-memory against cached full catalog data (no per-keystroke API calls).
+
+### 5.2 Add item flow
+
+- User taps add action from Items screen.
+- `AddItemView` requires category + name.
+- Save calls create endpoint.
+- On success, dismiss and update local item cache.
+
+### 5.3 Edit item flow
+
+- User selects an item from list.
+- `ItemEditorView` shows:
+  - editable name
+  - editable category
+  - `In Shopping List` toggle (only place this toggle exists)
+  - destructive delete button
+- Save for name/category uses item update endpoint.
+- Toggle ON uses add-to-list endpoint.
+- Toggle OFF uses remove-from-list endpoint.
+
+### 5.4 Delete flow
+
+- Delete action presents confirmation dialog.
+- Confirm executes item delete endpoint.
+- On success, pop back to list and remove item from cache.
+
+---
+
+## 6. Cross-Tab Consistency Contract
+
+When list-membership changes in `ItemEditorView`, the Shopping List tab must reflect that change.
+
+### Chosen strategy
+
+- Use event-based synchronization (`NotificationCenter`) with a shared constant:
+  - Name: `Notification.Name.itemsMembershipDidChange`
+  - Defined in `Shared/AppEvents.swift`
+- Notification payload (`userInfo`) contract:
+  - `itemID: Int`
+  - `isInList: Bool`
+  - `changedAt: Date`
+- Emission rule:
+  - Emit **only after a successful** membership mutation response.
+  - Emit on main actor after local editor state is updated.
+- Observer behavior:
+  - `ShoppingListView` subscribes on appear and unsubscribes on disappear.
+  - On event receipt, request refresh through a small refresh coordinator.
+- Coalescing rule:
+  - If multiple triggers arrive within 300ms, collapse to one refresh request.
+- Navigation safety net:
+  - `ShoppingListView` triggers `refreshIfNeeded()` on appear so returning from Items always revalidates list state.
+  - Tab reselection (tapping the already-active List tab) is not required in v1 because standard SwiftUI `TabView` does not provide a stable built-in reselection signal without UIKit bridging.
+
+### Refresh coordinator rules
+
+- `ShoppingListView` owns a lightweight coordinator with:
+  - `isRefreshing` gate (ignore additional triggers while refresh is in flight).
+  - `lastRefreshRequestAt` timestamp for 300ms dedupe window.
+- Trigger sources:
+  - membership-change notification
+  - `onAppear` safety refresh
+- Both trigger sources call the same coordinator entry point to guarantee deterministic behavior in notification + navigation races.
+
+This provides deterministic visible consistency without introducing a shared global store in this iteration.
+
+---
+
+## 7. Error Handling & UX Rules
+
+- Keep pessimistic commit behavior for mutating actions.
+  - Show in-flight state while request is pending.
+  - Update UI state only after request success.
+- Reuse existing API error mapping and present clear inline feedback.
+- Validation:
+  - Name is required and trimmed.
+  - Category selection is required for add and edit.
+- Delete conflict (`409`) keeps editor open and displays the returned message.
+- Disable Save/Delete/toggle controls while their corresponding request is in flight.
+- Accessibility labels and destructive semantics are required for key controls.
+
+### Mutation concurrency matrix
+
+- While **save name/category** is in flight:
+  - Disable save button, fields, list-membership toggle, and delete button.
+- While **toggle membership** is in flight:
+  - Disable toggle control, save button, fields, and delete button.
+- While **delete** is in flight:
+  - Disable all controls and keep confirmation dialog dismissed.
+- While **add item** is in flight (`AddItemView`):
+  - Disable save button and form controls (name/category).
+- Repeated taps on a disabled control are ignored.
+- No cancellation path is exposed for in-flight item mutations in v1.
+
+### Failure semantics
+
+- `404` on save/toggle/delete:
+  - Show server message.
+  - Keep editor visible.
+  - Offer retry; no optimistic local cache mutation is applied.
+- `409` on delete (in-use item):
+  - Show conflict message from server.
+  - Keep editor visible.
+  - No local cache mutation.
+- Generic network/server failures:
+  - Show inline error.
+  - Preserve prior visible state (pessimistic commit).
+
+---
+
+## 8. Testing Strategy
+
+### API-level tests
+
+- Verify `createItem` request method/path/body and decoding.
+- Verify `updateItem` request method/path/body and decoding.
+- Verify `deleteItem` request method/path.
+- Verify `listItems(categoryID:inList:)` query encoding and decoding.
+- Verify `404/409` status mapping for item mutation endpoints.
+
+### ViewModel tests
+
+- Search filtering behavior (case-insensitive substring).
+- `In List only` filter composition with search.
+- Add success updates local items.
+- Add flow prevents duplicate submit while request is in flight.
+- Edit success updates local fields.
+- Membership toggle updates state only on success.
+- Membership toggle failure preserves prior UI state and surfaces error.
+- Delete success removes item.
+- Delete conflict surfaces error and preserves editor/list state.
+- Add/Edit validation rejects trimmed-empty names.
+- Add/Edit validation requires category selection.
+- Rapid repeated toggle attempts do not send overlapping mutations.
+- Initial load failure keeps empty-safe UI and allows manual retry.
+- Pull-to-refresh replaces stale local cache with latest categories/items.
+
+### Navigation tests
+
+- Ensure tab order is `List`, `Items`, `Account`.
+- Ensure returning to Shopping List view from Items triggers the on-appear refresh path.
+
+### Cross-feature sync tests
+
+- Verify membership-change notification posts only on successful toggle.
+- Verify failed toggle does not emit notification.
+- Verify notification payload contract includes `itemID`, `isInList`, and `changedAt` with expected value types.
+- Verify Shopping List reacts to notification by refreshing once when notifications are bursty.
+- Verify notification + immediate tab switch race still results in exactly one refresh.
+- Verify notification received during in-flight refresh is deduped (no overlapping refreshes).
+
+### Simulator verification
+
+- Add item (category required).
+- Edit name and category.
+- Toggle in-list from editor and verify Shopping List reflects change.
+- Delete with confirmation dialog.
+- Confirm failed toggle/save/delete preserves previous visible state with clear error message.
+
+---
+
+## 9. Non-Goals and Follow-Up Options
+
+Possible future iterations, explicitly deferred from this feature:
+
+- Shared observable app store for richer cross-feature sync.
+- Bulk item management actions.
+- Server-driven filtered item pagination for very large catalogs.
+- SSE integration for live item/list consistency.


### PR DESCRIPTION
## Summary
- Add a dedicated iOS Items feature (tab, list/search/filter, add form, editor route) with required category/name validation and destructive delete confirmation.
- Add GroceriesAPI item endpoints/models and comprehensive API + feature tests for add/edit/delete/toggle semantics, in-flight gating, and failure behavior.
- Keep Shopping List consistent via shared membership-change app events and deduped refresh coordination, including decoupled toggle-on success from follow-up refetch.

## Test Plan
- [x] xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesAPI -destination 'platform=iOS Simulator,name=iPhone 17'
- [x] xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesTests -destination 'platform=iOS Simulator,name=iPhone 17'
- [x] xcodebuild test -project clients/ios/Groceries.xcodeproj -scheme GroceriesTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:GroceriesTests/ItemsViewModelTests