### PR TITLE
fix(ios): make item search field dismissible via native searchable

### DIFF
--- a/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
+++ b/clients/ios/Sources/Groceries/Features/Items/ItemsView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import GroceriesAPI
+import SwiftUI
 
 enum ItemsViewRoute: Hashable {
     case editor(itemID: Int)
@@ -74,15 +74,6 @@ struct ItemsView: View {
 
                 List {
                     Section {
-                        TextField(
-                            "Search items",
-                            text: Binding(
-                                get: { viewModel.searchText },
-                                set: { viewModel.searchText = $0 }
-                            )
-                        )
-                        .accessibilityLabel(ItemsViewAccessibility.searchFieldLabel)
-
                         Toggle(
                             "In List only",
                             isOn: Binding(
@@ -102,13 +93,16 @@ struct ItemsView: View {
                                 mutationErrorMessage: viewModel.mutationErrorMessage
                             ) {
                                 ContentUnavailableView {
-                                    Label("Unable to load items", systemImage: "exclamationmark.triangle")
+                                    Label(
+                                        "Unable to load items",
+                                        systemImage: "exclamationmark.triangle")
                                 } description: {
                                     Text("Please try again.")
                                 } actions: {
                                     Button("Retry") {
                                         Task {
-                                            await ItemsViewUX.performRetry(using: viewModel.retryLoad)
+                                            await ItemsViewUX.performRetry(
+                                                using: viewModel.retryLoad)
                                         }
                                     }
                                 }
@@ -134,7 +128,10 @@ struct ItemsView: View {
                                             .foregroundStyle(.white.opacity(0.75))
                                     }
                                     .accessibilityElement(children: .combine)
-                                    .accessibilityLabel(item.list == nil ? "\(item.name), \(item.categoryName)" : "\(item.name), \(item.categoryName), in list")
+                                    .accessibilityLabel(
+                                        item.list == nil
+                                            ? "\(item.name), \(item.categoryName)"
+                                            : "\(item.name), \(item.categoryName), in list")
                                 }
                             }
                         }
@@ -146,9 +143,18 @@ struct ItemsView: View {
                 .refreshable {
                     await viewModel.refresh()
                 }
+                .scrollDismissesKeyboard(.immediately)
             }
             .navigationTitle("Items")
             .navigationBarTitleDisplayMode(.inline)
+            .searchable(
+                text: Binding(
+                    get: { viewModel.searchText },
+                    set: { viewModel.searchText = $0 }
+                ),
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "Search items"
+            )
             .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbarBackground(.clear, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
@@ -165,7 +171,9 @@ struct ItemsView: View {
             .task { await viewModel.load() }
             .sheet(isPresented: $isPresentingAddItem) {
                 AddItemView(viewModel: viewModel)
-                    .interactiveDismissDisabled(ItemsViewUX.addSheetInteractiveDismissDisabled(isAdding: viewModel.isAdding))
+                    .interactiveDismissDisabled(
+                        ItemsViewUX.addSheetInteractiveDismissDisabled(isAdding: viewModel.isAdding)
+                    )
             }
         }
     }

--- a/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
+++ b/clients/ios/Tests/GroceriesTests/Features/Items/ItemsViewModelTests.swift
@@ -5,7 +5,9 @@ import XCTest
 
 @MainActor
 final class ItemsViewModelTests: XCTestCase {
-    func test_filteredItems_matchesCaseInsensitiveSubstring() async throws {
+    func test_filteredItems_matchesCaseInsensitiveSubstring_andClearingSearchRestoresFullList()
+        async throws
+    {
         let api = MockItemsAPI(
             categories: try decodeCategories(
                 """
@@ -51,6 +53,10 @@ final class ItemsViewModelTests: XCTestCase {
         viewModel.searchText = "mIlK"
 
         XCTAssertEqual(viewModel.filteredItems.map(\.name), ["Almond Milk", "Whole Milk"])
+
+        viewModel.searchText = ""
+
+        XCTAssertEqual(viewModel.filteredItems.map(\.name), ["Almond Milk", "Whole Milk", "Bread"])
     }
 
     func test_filteredItems_composesInListOnlyAndSearch() async throws {
@@ -259,7 +265,8 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertTrue(addOK)
         XCTAssertEqual(viewModel.items.map(\.name), ["Oat Milk"])
 
-        let updateOK = await viewModel.updateItem(id: 10, name: "Oat Milk Unsweetened", categoryID: 1)
+        let updateOK = await viewModel.updateItem(
+            id: 10, name: "Oat Milk Unsweetened", categoryID: 1)
         XCTAssertTrue(updateOK)
         XCTAssertEqual(viewModel.items.map(\.name), ["Oat Milk Unsweetened"])
 
@@ -401,7 +408,8 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertNotNil(userInfo[AppEvents.MembershipChanged.changedAtKey] as? Date)
     }
 
-    func test_setInListToggleOffSuccess_callsRemoveRefreshesAndPostsFalseNotification() async throws {
+    func test_setInListToggleOffSuccess_callsRemoveRefreshesAndPostsFalseNotification() async throws
+    {
         let notificationCenter = NotificationCenter()
         let original = try decodeItem(
             """
@@ -454,7 +462,9 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertEqual(userInfo[AppEvents.MembershipChanged.isInListKey] as? Bool, false)
     }
 
-    func test_setInListToggleOn_refreshFailure_stillSucceedsPostsNotificationAndUpdatesLocalState() async throws {
+    func test_setInListToggleOn_refreshFailure_stillSucceedsPostsNotificationAndUpdatesLocalState()
+        async throws
+    {
         let notificationCenter = NotificationCenter()
         let original = try decodeItem(
             """
@@ -509,7 +519,9 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertEqual(userInfo[AppEvents.MembershipChanged.isInListKey] as? Bool, true)
     }
 
-    func test_setInListToggleOff_refreshFailure_stillSucceedsPostsNotificationAndUpdatesLocalState() async throws {
+    func test_setInListToggleOff_refreshFailure_stillSucceedsPostsNotificationAndUpdatesLocalState()
+        async throws
+    {
         let notificationCenter = NotificationCenter()
         let original = try decodeItem(
             """
@@ -591,7 +603,9 @@ final class ItemsViewModelTests: XCTestCase {
         XCTAssertEqual(recorder.count, 0)
     }
 
-    func test_toggleAndDeleteFailure_preserveState_andToggleFailureDoesNotPostNotification() async throws {
+    func test_toggleAndDeleteFailure_preserveState_andToggleFailureDoesNotPostNotification()
+        async throws
+    {
         let notificationCenter = NotificationCenter()
         let original = try decodeItem(
             """
@@ -1187,7 +1201,8 @@ final class ItemsViewModelTests: XCTestCase {
 
     func test_itemEditorControlsDisabled_whileMutationInFlight() {
         XCTAssertTrue(ItemEditorViewUX.cancelDisabled(isMutationInFlight: true))
-        XCTAssertTrue(ItemEditorViewUX.saveDisabled(isMutationInFlight: true, baseSaveDisabled: false))
+        XCTAssertTrue(
+            ItemEditorViewUX.saveDisabled(isMutationInFlight: true, baseSaveDisabled: false))
         XCTAssertTrue(ItemEditorViewUX.nameDisabled(isMutationInFlight: true))
         XCTAssertTrue(ItemEditorViewUX.categoryDisabled(isMutationInFlight: true))
         XCTAssertTrue(ItemEditorViewUX.membershipToggleDisabled(isMutationInFlight: true))
@@ -1197,7 +1212,8 @@ final class ItemsViewModelTests: XCTestCase {
     func test_itemEditorAccessibilityLabels_remainStable() {
         XCTAssertEqual(ItemEditorViewAccessibility.categoryLabel, "Edit item category")
         XCTAssertEqual(ItemEditorViewAccessibility.nameLabel, "Edit item name")
-        XCTAssertEqual(ItemEditorViewAccessibility.membershipToggleLabel, "Include item in shopping list")
+        XCTAssertEqual(
+            ItemEditorViewAccessibility.membershipToggleLabel, "Include item in shopping list")
         XCTAssertEqual(ItemEditorViewAccessibility.cancelButtonLabel, "Cancel edit item")
         XCTAssertEqual(ItemEditorViewAccessibility.saveButtonLabel, "Save item changes")
         XCTAssertEqual(ItemEditorViewAccessibility.deleteButtonLabel, "Delete item")
@@ -1346,7 +1362,10 @@ private final class MockItemsAPI: ItemsAPI {
     private(set) var addItemToListCallCount = 0
     private(set) var removeItemFromListCallCount = 0
 
-    init(categories: [GroceriesAPI.Category], items: [Item], listCategoriesError: Error? = nil, listItemsError: Error? = nil) {
+    init(
+        categories: [GroceriesAPI.Category], items: [Item], listCategoriesError: Error? = nil,
+        listItemsError: Error? = nil
+    ) {
         self.categories = categories
         self.items = items
         self.listCategoriesError = listCategoriesError


### PR DESCRIPTION
## Summary

Fixes #42.

The Items screen search field was a custom `TextField` embedded in a list row. Once the on-screen keyboard appeared there was no reachable clear/cancel affordance, so the keyboard could cover the app's navigation and "soft lock" the screen (as described in the issue, observed when running the iOS app on macOS).

## Changes

- Replaced the custom `TextField` in `ItemsView` with SwiftUI's native `.searchable()` modifier, attached to the navigation bar (`.navigationBarDrawer(displayMode: .always)`). This is the standard HIG-compliant iOS search pattern (Mail, Notes, Reminders, etc.) and provides, for free:
  - A built-in clear (×) button once text is entered
  - An always-visible **Cancel** affordance in the nav bar area (never covered by the keyboard) to dismiss both search and the keyboard
  - Native search keyboard return key behavior
- Added `.scrollDismissesKeyboard(.immediately)` on the item list as an additional safety net for dismissing the keyboard.
- No changes to `ItemsViewModel` — existing `searchText` / `applyFilters()` filtering logic is unchanged and now binds directly to the native search field.

## Testing

- Extended `ItemsViewModelTests` to assert that clearing `searchText` restores the full item list (the testable logic behind "clear").
- Ran `tuist generate --path clients/ios` and `xcodebuild test -scheme GroceriesTests` on an iPhone 17 simulator — all 43 tests pass.
- UI-level keyboard/Cancel-button behavior isn't unit-testable and should be spot-checked manually on device/simulator.
