### PR TITLE
feat: add Playwright end-to-end tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,16 @@ jobs:
       - uses: jdx/mise-action@v3
       - run: mise run test
 
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v3
+      - run: mise run test:e2e
+
   deploy:
     uses: taiidani/deploy-action/.github/workflows/deploy.yml@main
-    needs: [build, lint, test]
+    needs: [build, lint, test, e2e]
     if: ${{ github.ref == 'refs/heads/main' }}
     with:
       filename: "${{ needs.build.outputs.filename }}"

--- a/mise.toml
+++ b/mise.toml
@@ -17,6 +17,7 @@ GOOSE_MIGRATION_DIR = "./internal/db/migrations"
 [tools]
 go = "1.25.1"
 tuist = "latest"
+node = "24.18.0"
 "go:github.com/evanw/esbuild/cmd/esbuild" = "latest"
 
 [vars]
@@ -61,6 +62,11 @@ run = ["go tool goose --no-versioning up"]
 [tasks.lint]
 depends = ["dependencies"]
 run = ["go vet ./...", "go tool staticcheck ./..."]
+
+[tasks."test:e2e"]
+description = "Run Playwright end-to-end browser tests against a live instance of the app"
+depends = ["build"]
+run = ["./tests/run.sh"]
 
 [tasks.plugin]
 description = "Bundle and deploy the Aisle4 Obsidian plugin to the vault"

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,45 @@
+# End-to-end tests
+
+Playwright-based end-to-end browser tests for the Groceries web app.
+
+These tests exercise the app the same way a user would: through a real
+browser, against a live instance of the server backed by real Postgres and
+Redis instances (the same ones defined in the root [docker-compose.yml](../docker-compose.yml)).
+
+## Running
+
+From the repository root:
+
+```bash
+mise run test:e2e
+```
+
+This will:
+
+1. Start Postgres and Redis via `docker compose up -d`.
+2. Start the compiled `./groceries` server binary (which applies database
+   migrations automatically on startup).
+3. Populate the database with deterministic seed data (`mise run seed`).
+4. Install Playwright's Chromium browser and its dependencies.
+5. Run the Playwright test suite in `tests/e2e/`.
+6. Tear down the server process and docker compose services.
+
+The suite currently runs Chromium only. Test files run serially (not in
+parallel) because they mutate shared application state (the grocery list) in
+the same way multiple users of the app would.
+
+## Running Playwright directly
+
+If the app and its dependencies are already running locally (e.g. via
+`mise run default`) and seeded (`mise run seed`), you can iterate on the
+tests without going through the full orchestration script:
+
+```bash
+cd tests
+npm install
+npx playwright test          # headless run
+npx playwright test --ui     # interactive UI mode
+```
+
+Set `BASE_URL` if the app isn't running on the default
+`http://localhost:3000`.

--- a/tests/e2e/shopping-list.spec.js
+++ b/tests/e2e/shopping-list.spec.js
@@ -1,0 +1,64 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+// These tests rely on the deterministic seed data loaded by `mise run seed`
+// (see internal/db/seeds). "Apples" is seeded as an item that exists in the
+// catalog but starts off the shopping list, making it a safe item to
+// exercise the add/done/checkout flow without disturbing other seeded data.
+const TEST_USERNAME = "admin";
+const TEST_PASSWORD = "marbleslyra";
+const TEST_ITEM = "Apples";
+
+test.describe.configure({ mode: "serial" });
+
+test("shopping list journey: login, add, mark done, and check out", async ({
+  page,
+}) => {
+  await test.step("can log in", async () => {
+    await page.goto("/login");
+
+    await page.getByPlaceholder("Username").fill(TEST_USERNAME);
+    await page.getByPlaceholder("Password").fill(TEST_PASSWORD);
+    await page.getByRole("button", { name: "Login" }).click();
+
+    await expect(page).toHaveURL("/");
+    await expect(page.getByRole("link", { name: "Logout" })).toBeVisible();
+  });
+
+  await test.step("can dynamically add an existing item to the list", async () => {
+    await page.goto("/");
+
+    // The "name" field is backed by a <datalist> of items that are not yet
+    // on the shopping list, confirming this exercises the "existing item"
+    // path (as opposed to creating a brand new item).
+    await expect(
+      page.locator('#list-add-items option[value="Apples"]'),
+    ).toHaveCount(1);
+
+    await page.locator("#name").fill(TEST_ITEM);
+    // Scoped to the form's submit button specifically: BeerCSS renders an
+    // icon ligature ahead of the button text (e.g. "add Add"), which makes
+    // a plain accessible-name match for "Add" ambiguous with the circle
+    // "add_shopping_cart" icon buttons elsewhere on the page.
+    await page.locator('button[form="itemAdderForm"]').click();
+
+    await expect(page).toHaveURL("/");
+    await expect(page.locator("#list").getByText(TEST_ITEM)).toBeVisible();
+  });
+
+  await test.step("can mark an item done in the list and see it appear in the shopping cart", async () => {
+    const listItem = page.locator("#list li.item", { hasText: TEST_ITEM });
+    await expect(listItem).toBeVisible();
+    await listItem.locator('button[hx-post="/list/done"]').click();
+
+    await expect(page.locator("#list").getByText(TEST_ITEM)).toHaveCount(0);
+    await expect(page.locator("#cart").getByText(TEST_ITEM)).toBeVisible();
+  });
+
+  await test.step("can check out the shopping cart and see all done items be cleared", async () => {
+    await page.locator('#cart button[hx-post="/list/finish"]').click();
+
+    await expect(page.locator("#cart").getByText(TEST_ITEM)).toHaveCount(0);
+    await expect(page.locator("#list").getByText(TEST_ITEM)).toHaveCount(0);
+  });
+});

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "groceries-e2e-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "groceries-e2e-tests",
+      "devDependencies": {
+        "@playwright/test": "^1.61.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "groceries-e2e-tests",
+  "private": true,
+  "description": "Playwright end-to-end tests for the Groceries web app",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.61.1"
+  }
+}

--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -1,0 +1,31 @@
+// @ts-check
+const { defineConfig, devices } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: "./e2e",
+
+  // The tests share a single instance of the app and mutate the same
+  // database state, so they must not run concurrently against each other.
+  fullyParallel: false,
+  workers: 1,
+
+  forbidOnly: !!process.env.CI,
+  // Retries are intentionally disabled: these tests mutate shared database
+  // state (the grocery list), so a retried test would not start from a
+  // clean slate.
+  retries: 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+
+  use: {
+    baseURL: process.env.BASE_URL || "http://localhost:3000",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Spins up the app's dependencies and a live instance of the server, runs the
+# Playwright end-to-end test suite against it, and tears everything down
+# again. Intended to be invoked via `mise run test:e2e`.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+APP_PID=""
+COMPOSE_STARTED=0
+
+cleanup() {
+  if [ -n "$APP_PID" ]; then
+    echo "==> Stopping application server"
+    kill "$APP_PID" 2>/dev/null || true
+    wait "$APP_PID" 2>/dev/null || true
+  fi
+
+  if [ "$COMPOSE_STARTED" = "1" ]; then
+    echo "==> Stopping docker compose services"
+    docker compose down
+  fi
+}
+trap cleanup EXIT
+
+wait_for_port() {
+  local host="$1" port="$2" name="$3"
+  for _ in $(seq 1 60); do
+    if (exec 3<>"/dev/tcp/${host}/${port}") 2>/dev/null; then
+      exec 3>&- 3<&-
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Timed out waiting for ${name} on ${host}:${port}" >&2
+  return 1
+}
+
+echo "==> Starting dependencies (postgres, redis)"
+docker compose up -d
+COMPOSE_STARTED=1
+
+wait_for_port 127.0.0.1 5432 postgres
+wait_for_port 127.0.0.1 6379 redis
+
+# Postgres accepts TCP connections slightly before it's ready to
+# authenticate/serve queries during its first-time initialization; give it a
+# moment so the app's first connection attempt doesn't predictably fail.
+sleep 3
+
+echo "==> Starting application server (this also applies database migrations)"
+started=0
+for attempt in $(seq 1 5); do
+  ./groceries > /tmp/groceries-e2e.log 2>&1 &
+  APP_PID=$!
+
+  healthy=0
+  for _ in $(seq 1 30); do
+    if ! kill -0 "$APP_PID" 2>/dev/null; then
+      break
+    fi
+    if curl --silent --fail --output /dev/null "http://localhost:${PORT:-3000}/login"; then
+      healthy=1
+      break
+    fi
+    sleep 1
+  done
+
+  if [ "$healthy" = "1" ]; then
+    started=1
+    break
+  fi
+
+  echo "==> Application did not become healthy on attempt ${attempt}, retrying..."
+  kill "$APP_PID" 2>/dev/null || true
+  wait "$APP_PID" 2>/dev/null || true
+  APP_PID=""
+  sleep 2
+done
+
+if [ "$started" != "1" ]; then
+  echo "Application server never became healthy. Logs:" >&2
+  cat /tmp/groceries-e2e.log >&2 || true
+  exit 1
+fi
+
+echo "==> Seeding database with deterministic test data"
+mise run seed
+
+echo "==> Installing Playwright and its dependencies"
+cd tests
+npm ci
+npx playwright install --with-deps chromium
+
+echo "==> Running Playwright end-to-end tests"
+npx playwright test


### PR DESCRIPTION
## Summary

Implements #43 by adding a Playwright-based end-to-end test suite that exercises the app through a real browser against a live instance backed by real Postgres/Redis (via the root `docker-compose.yml`).

The suite covers the four scenarios called out in the issue, as steps within a single journey test (they build on shared state):
- Can log in
- Can dynamically add an existing item to the list
- Can mark an item done in the list and see it appear in the shopping cart
- Can check out the shopping cart and see all done items be cleared

## Implementation

- `tests/` is a self-contained Node project, isolated from the Go module, with a single dependency (`@playwright/test`) to keep the footprint minimal while using the most widely-supported Playwright variant.
- `tests/run.sh` orchestrates the full lifecycle: `docker compose up` (postgres/redis) -> start the `./groceries` binary (which applies DB migrations itself on boot) -> `mise run seed` for deterministic fixtures -> install Playwright's Chromium browser -> run the suite -> tear everything down.
- `mise run test:e2e` wires this into the existing task runner; `node` is now a pinned tool in `mise.toml` alongside `go`.
- CI: a new `e2e` job in `.github/workflows/build.yml` runs on every push, alongside `build`/`lint`/`test`, and gates `deploy`.
- Chromium only for now, per scope discussion - easy to add more browser projects to `playwright.config.js` later.

## Testing

Ran `mise run test:e2e` locally against real Docker-backed Postgres/Redis - full pipeline (compose up, app boot + migrate, seed, browser install, test run, teardown) passes.

Closes #43
